### PR TITLE
Initialize docker builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,26 @@
+# Build Docker image and publish to KU Leuven MICAS Platform
+name: build-docker
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  build-docker:
+    name: Deploy Docker Image
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - name: GHCR Log-in
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/container/Dockerfile
+          push: true
+          tags: ghcr.io/kuleuven-micas/hypercorex:main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cocotb==1.8.0
+cocotb-test==0.2.4
+pytest==7.4.0
+mako==1.3.0
+jsonref==1.1.0
+hjson==3.1.0
+pre-commit
+ruff
+black
+# pyright version has to be fixed with '=='. the CI parses this file
+# and installs the exact version for type-checking
+pyright==1.1.323

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04
+
+# Install verilator dependencies and python for cocotb and pytest
+RUN apt-get update && \
+    apt-get -y install \
+    git \
+    autoconf \
+    help2man \
+    perl \
+    python3 \
+    python3-pip \
+    make \
+    flex \
+    bison \
+    g++ \
+    libfl2 \
+    libfl-dev \
+    curl \
+    openjdk-11-jre-headless openjdk-11-jdk-headless \
+    wget \
+    tar \
+    gnupg2 \
+    software-properties-common \
+    lsb-release \
+    git \
+    tar \
+    unzip \
+    python3-pip
+
+# Install Verilator
+RUN git clone https://github.com/verilator/verilator && \
+  cd verilator && \
+  git checkout stable && \
+  unset VERILATOR_ROOT && \
+  autoconf && \
+  ./configure && \
+  make -j$(nproc) && \
+  make install && \
+  cd .. && \
+  rm -rf verilator && \
+  rm -rf /root/.cache
+
+# Get bender binary
+# Bender
+RUN cd /usr/bin && curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh -s 0.28.1 && cd /
+
+# Verible
+RUN wget https://github.com/chipsalliance/verible/releases/download/v${VERIBLE_VERSION}/verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz && \
+    mkdir tempdir && \
+    tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C tempdir && \
+    cp -rn tempdir/bin/* ./bin/ && \
+    rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz tempdir
+
+# Install python dependencies
+WORKDIR /repo
+COPY requirements.txt .
+RUN pip install -r requirements.txt


### PR DESCRIPTION
This PR initializes the repo with the Dockerfile needed for RTL runs.

The goal is to set `cocotb` as the main simulator because it can switch between Verilator and Questasim seamlessly.