### PR TITLE
Fix docker problem for Verilator builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ hjson
 pre-commit
 ruff
 black
-# pyright version has to be fixed with '=='. the CI parses this file
-# and installs the exact version for type-checking
 pyright
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-cocotb==1.8.0
-cocotb-test==0.2.4
-pytest==7.4.0
-mako==1.3.0
-jsonref==1.1.0
-hjson==3.1.0
+cocotb
+cocotb-test
+pytest
+mako
+jsonref
+hjson
 pre-commit
 ruff
 black
 # pyright version has to be fixed with '=='. the CI parses this file
 # and installs the exact version for type-checking
-pyright==1.1.323
+pyright

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,35 +1,35 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS base
 
 # Install verilator dependencies and python for cocotb and pytest
-RUN apt-get update && \
-    apt-get -y install \
-    git \
-    autoconf \
-    help2man \
-    perl \
-    python3 \
-    python3-pip \
-    make \
-    flex \
-    bison \
-    g++ \
-    libfl2 \
-    libfl-dev \
-    curl \
-    openjdk-11-jre-headless openjdk-11-jdk-headless \
-    wget \
-    tar \
-    gnupg2 \
-    software-properties-common \
-    lsb-release \
-    git \
-    tar \
-    unzip \
-    python3-pip
-
-# Verible
-ENV VLT_ROOT /usr/local/share/verilator
-ENV VERIBLE_VERSION 0.0-3644-g6882622d
+RUN apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg curl && \
+  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh && \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  build-essential \
+  device-tree-compiler \
+  git \
+  gnupg2 \
+  lsb-release \
+  software-properties-common \
+  tar \
+  unzip \
+  wget \
+  zlib1g-dev \
+  zsh \
+  vim \
+  nano \
+  openjdk-11-jre-headless openjdk-11-jdk-headless \
+  mlir-17-tools clang-format-17 python3 \
+  help2man perl make autoconf g++ flex bison ccache \
+  libgoogle-perftools-dev numactl perl-doc \
+  libfl2 libfl-dev zlib1g zlib1g-dev \
+  sbt \
+  python3-pip && \
+  # create symbolic links for all *-17 binaries
+  for f in /usr/bin/*-17; do ln -s $f ${f%-17}; done && \
+  # Update pip for git installs
+  pip3 install --upgrade pip
 
 # Install Verilator
 RUN git clone https://github.com/verilator/verilator && \
@@ -43,6 +43,9 @@ RUN git clone https://github.com/verilator/verilator && \
   cd .. && \
   rm -rf verilator && \
   rm -rf /root/.cache
+
+ENV VLT_ROOT /usr/local/share/verilator
+ENV VERIBLE_VERSION 0.0-3644-g6882622d
 
 # Get bender binary
 # Bender

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,35 +1,35 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.04
 
 # Install verilator dependencies and python for cocotb and pytest
-RUN apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg curl && \
-  wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17 && rm llvm.sh && \
-  apt-get update && \
-  apt-get upgrade -y && \
-  apt-get install -y \
-  build-essential \
-  device-tree-compiler \
-  git \
-  gnupg2 \
-  lsb-release \
-  software-properties-common \
-  tar \
-  unzip \
-  wget \
-  zlib1g-dev \
-  zsh \
-  vim \
-  nano \
-  openjdk-11-jre-headless openjdk-11-jdk-headless \
-  mlir-17-tools clang-format-17 python3 \
-  help2man perl make autoconf g++ flex bison ccache \
-  libgoogle-perftools-dev numactl perl-doc \
-  libfl2 libfl-dev zlib1g zlib1g-dev \
-  sbt \
-  python3-pip && \
-  # create symbolic links for all *-17 binaries
-  for f in /usr/bin/*-17; do ln -s $f ${f%-17}; done && \
-  # Update pip for git installs
-  pip3 install --upgrade pip
+RUN apt-get update && \
+    apt-get -y install \
+    git \
+    autoconf \
+    help2man \
+    perl \
+    python3 \
+    python3-pip \
+    make \
+    flex \
+    bison \
+    g++ \
+    libfl2 \
+    libfl-dev \
+    curl \
+    openjdk-11-jre-headless openjdk-11-jdk-headless \
+    wget \
+    tar \
+    gnupg2 \
+    software-properties-common \
+    lsb-release \
+    git \
+    tar \
+    unzip \
+    python3-pip
+
+# Verible
+ENV VLT_ROOT /usr/local/share/verilator
+ENV VERIBLE_VERSION 0.0-3644-g6882622d
 
 # Install Verilator
 RUN git clone https://github.com/verilator/verilator && \
@@ -43,9 +43,6 @@ RUN git clone https://github.com/verilator/verilator && \
   cd .. && \
   rm -rf verilator && \
   rm -rf /root/.cache
-
-ENV VLT_ROOT /usr/local/share/verilator
-ENV VERIBLE_VERSION 0.0-3644-g6882622d
 
 # Get bender binary
 # Bender

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -13,17 +13,23 @@ RUN apt-get update && \
     flex \
     bison \
     g++ \
+    ccache \
     libfl2 \
     libfl-dev \
+    libgoogle-perftools-dev numactl perl-doc \
     curl \
     openjdk-11-jre-headless openjdk-11-jdk-headless \
     wget \
     tar \
     gnupg2 \
+    zlib1g zlib1g-dev \
     software-properties-common \
     lsb-release \
     git \
     tar \
+    zsh \
+    vim \
+    nano \
     unzip \
     python3-pip
 
@@ -53,6 +59,15 @@ RUN wget https://github.com/chipsalliance/verible/releases/download/v${VERIBLE_V
     tar -x -f verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz --strip-components=1 -C tempdir && \
     cp -rn tempdir/bin/* ./bin/ && \
     rm -rf verible-v${VERIBLE_VERSION}-linux-static-x86_64.tar.gz tempdir
+
+# Install Oh-My-Zsh and Autocomplete Plugin
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended && \
+git clone https://github.com/zsh-users/zsh-autosuggestions.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions && \
+echo "source ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc && \
+chsh -s $(which zsh)
+
+# Zsh as default shell
+CMD ["zsh"]
 
 # Install python dependencies
 WORKDIR /repo


### PR DESCRIPTION
This PR updates the `requirements.txt` to avoid the old C++ compiler.

We also add useful tools like black and flake8.

We also add the zsh into the docker for more style.