### PR TITLE
Add circular shift to ALU

### DIFF
--- a/rtl/hv_alu_pe.sv
+++ b/rtl/hv_alu_pe.sv
@@ -8,10 +8,11 @@
 // operations for hypervectors
 //---------------------------
 module hv_alu_pe #(
-  parameter int unsigned HVDimension  = 512,
-  parameter int unsigned NumOps       = 4,
-  parameter int unsigned NumOpsWidth  = $clog2(NumOps),
-  parameter int unsigned PermuteWidth = 5
+  parameter int unsigned HVDimension   = 512,
+  parameter int unsigned NumOps        = 4,
+  parameter int unsigned NumOpsWidth   = $clog2(NumOps),
+  parameter int unsigned MaxShiftAmt   = 128,
+  parameter int unsigned PermuteWidth  = $clog2(MaxShiftAmt)
 )(
   // Inputs
   input  logic [ HVDimension-1:0] A_i,
@@ -19,20 +20,32 @@ module hv_alu_pe #(
   // Outputs
   output logic [ HVDimension-1:0] C_o,
   // Control ports
-  input  logic [ NumOpsWidth-1:0] op_i
+  input  logic [ NumOpsWidth-1:0] op_i,
+  input  logic [PermuteWidth-1:0] shift_amt_i
 );
 
   //---------------------------
+  // Logic for shifting
+  //---------------------------
+  logic [HVDimension-1:0] circular_shift_res;
+
+  always_comb begin
+    circular_shift_res = (A_i >> shift_amt_i) | (A_i << (HVDimension - shift_amt_i));
+  end
+
+  //---------------------------
   // Logic table:
-  // op_i | operation                    |
-  // 0    | XOR                          |
-  // 1    | AND                          |
-  // 2    | OR                           |
+  // op_i | operation         |
+  // 0    | XOR               |
+  // 1    | AND               |
+  // 2    | OR                |
+  // 3    | Circular shifts   |
   //---------------------------
   always_comb begin : alu_logic
     case (op_i)
       2'b01:   C_o = A_i & B_i;
       2'b10:   C_o = A_i | B_i;
+      2'b11:   C_o = circular_shift_res;
       default: C_o = A_i ^ B_i;
     endcase
   end

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -12,3 +12,8 @@ TEST_RUNS = 20
 # Working dimensions
 HV_DIM = 256
 BUNDLER_COUNT_WIDTH = 8
+
+# Shift amount needs to be in odd number form
+# because the shifts is from 0 to some dimension
+# here, we restrict shift amount to be half of the total dimension
+MAX_SHIFT_AMT = HV_DIM / 2 - 1


### PR DESCRIPTION
This PR adds the circular shift function to the ALU.

Major TODOs:
- [x] Add circular shift to the HV ALU
- [x] Add circular shift test