### PR TITLE
Move the threshold to fully combinational logic

### DIFF
--- a/rtl/bundler_set.sv
+++ b/rtl/bundler_set.sv
@@ -17,9 +17,13 @@ module bundler_set#(
   input  logic [HVDimension-1:0] hv_i,
   input  logic valid_i,
   input  logic clr_i,
-  input  logic binarize_i,
-  output logic signed [HVDimension-1:0][CounterWidth-1:0] counter_o
+  output logic signed [HVDimension-1:0][CounterWidth-1:0] counter_o,
+  output logic [HVDimension-1:0] binarized_hv_o
 );
+
+  //---------------------------
+  // Bundler units
+  //---------------------------
 
   genvar i;
   for(i = 0; i < HVDimension; i++ )begin: gen_bundler_units
@@ -31,9 +35,19 @@ module bundler_set#(
       .bit_i        (hv_i[i]      ),
       .valid_i      (valid_i      ),
       .clr_i        (clr_i        ),
-      .binarize_i   (binarize_i   ),
       .counter_o    (counter_o[i] )
     );
   end
+
+  //---------------------------
+  // Combinational threshold
+  //---------------------------
+
+  always_comb begin
+    for(int i = 0; i < HVDimension; i++) begin
+      binarized_hv_o[i] = (counter_o[i] >= 0) ? 1'b1 : 1'b0;
+    end
+  end
+
 
 endmodule

--- a/rtl/bundler_unit.sv
+++ b/rtl/bundler_unit.sv
@@ -17,7 +17,6 @@ module bundler_unit #(
   input  logic bit_i,
   input  logic valid_i,
   input  logic clr_i,
-  input  logic binarize_i,
   output logic signed [CounterWidth-1:0] counter_o
 );
 
@@ -45,16 +44,9 @@ module bundler_unit #(
 
       // This is for synchronous reset
       if(clr_i) begin
+
         counter_o <= {CounterWidth{1'b0}};
 
-      // This is for binarizing the input
-      // Go to 1 or 0
-      end else if (binarize_i) begin
-        if(counter_o >= 0) begin
-          counter_o <= 1;
-        end else begin
-          counter_o <= 0;
-        end
       // This is for accumulating values
       end else if (valid_i) begin
 

--- a/tests/test_bundler_unit.py
+++ b/tests/test_bundler_unit.py
@@ -47,7 +47,6 @@ def print_all(dut):
     cocotb.log.info(f"bit_i: {dut.bit_i.value.integer}")
     cocotb.log.info(f"valid_i: {dut.valid_i.value.integer}")
     cocotb.log.info(f"clr_i: {dut.clr_i.value.integer}")
-    cocotb.log.info(f"binarize_i: {dut.binarize_i.value.integer}")
     cocotb.log.info(f"counter_o: {dut.counter_o.value.signed_integer}")
     return
 
@@ -68,21 +67,12 @@ async def decrement_inputs(dut):
     return
 
 
-# Binarize output
-async def binarize_output(dut):
-    dut.binarize_i.value = 1
-    await clock_and_time(dut.clk_i)
-    dut.binarize_i.value = 0
-    return
-
-
 # Clearing inputs but
 # without time progression
 def clear_inputs_no_clock(dut):
     dut.bit_i.value = 0
     dut.valid_i.value = 0
     dut.clr_i.value = 0
-    dut.binarize_i.value = 0
 
 
 """
@@ -121,17 +111,6 @@ async def bundler_unit_dut(dut):
     assert dut.counter_o.value.signed_integer >= 0, "Error! Bundler needs to increment!"
 
     cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("       Testing Positive Binarization        ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # Clear inputs first then set binarize signal
-    clear_inputs_no_clock(dut)
-    await binarize_output(dut)
-    print_counter_output(dut)
-
-    assert dut.counter_o.value.signed_integer == 1, "Error! Bundler needs to be 1!"
-
-    cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("        Testing Clearing of Bundler         ")
     cocotb.log.info(" ------------------------------------------ ")
 
@@ -155,17 +134,6 @@ async def bundler_unit_dut(dut):
     assert (
         dut.counter_o.value.signed_integer < 0
     ), "Error! Bundler needs to be cleared to 0!"
-
-    cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("       Testing Negative Binarization        ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # Clear inputs first then set binarize signal
-    clear_inputs_no_clock(dut)
-    await binarize_output(dut)
-    print_counter_output(dut)
-
-    assert dut.counter_o.value.signed_integer == 0, "Error! Bundler needs to be 0!"
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("       Testing Positive Saturation          ")


### PR DESCRIPTION
This PR moves the threshold to fully combinational logic. Useful for the data path later.

Major TODO:
- [x] Update `bundler_unit`
- [x] Update `bundler_set`
- [x] Update test for bundler unit
- [x] Update test for bundler set
