### PR TITLE
Add more experiments for CA 90

### DIFF
--- a/hdc_exp/cellular_automata.py
+++ b/hdc_exp/cellular_automata.py
@@ -10,11 +10,14 @@
 """
 
 import numpy as np
+from tqdm import tqdm
 from hdc_util import (
     gen_ri_hv,
     simple_plot2d,
     gen_hv_ca90_iterate_rows,
     gen_hv_ca90_hierarchical_rows,
+    gen_orthogonal_im,
+    gen_conf_mat,
 )
 
 
@@ -24,8 +27,8 @@ from hdc_util import (
         HV_DIM - hypervector dimensions
 """
 
-HV_SEED = 8
-HV_DIM = 1024
+HV_SEED = 32
+HV_DIM = 256
 HV_ORTHO_DIST = int(HV_DIM / 2)
 TEST_RUNS = 100
 
@@ -35,6 +38,25 @@ TEST_RUNS = 100
 """
 
 
+# Converting number to a binary numpy array
+def numbin2list(numbin, dim):
+    # Convert binary inputs first
+    bin_hv = np.array(list(map(int, format(numbin, f"0{dim}b"))))
+    return bin_hv
+
+
+# Convert from list to binary value
+def hvlist2num(hv_list):
+    # Bring back into an integer itself!
+    # Sad workaround is to convert to str
+    # The convert to integer
+    hv_num = "".join(hv_list.astype(str))
+    hv_num = int(hv_num, 2)
+
+    return hv_num
+
+
+# Getting averageand std of scores
 def gen_avg_std_scores(seed_list, ca90_mode="iter"):
     density_avg_list = []
     density_std_list = []
@@ -63,10 +85,33 @@ def gen_avg_std_scores(seed_list, ca90_mode="iter"):
     return density_avg_list, density_std_list
 
 
+# For finding indices
+def find_target_indices(lst, number):
+    return list(np.where(np.array(lst) == number)[0])
+
+
 """
-    Main function list
+    Test functions
 """
-if __name__ == "__main__":
+
+
+"""
+    seed_density_gen:
+        - This determines the average generated
+          density for different seed sizes.
+
+    gen_density_list:
+        - This is for generating a density list
+          used for identifying which HV seeds
+          generated the desired list!
+
+    extract_target_seeds:
+        - This function is for extracting seeds
+          That give the target 50% density of a base HV
+"""
+
+
+def seed_density_gen():
     # For different seed sizes,
     # will we get consistent HV density?
     seed_list = [4, 8, 16, 32, 64, 128, 256, 512, 1024]
@@ -103,3 +148,93 @@ if __name__ == "__main__":
         legend=True,
         single_plot=False,
     )
+
+    return
+
+
+def gen_density_list(seed_size, hv_dim, ca90_mode="iter"):
+    # Set total number of iterations
+    seed_iterations = 2**seed_size
+    half_dim = int(hv_dim / 2)
+
+    # Initialize density list
+    density_list = []
+
+    # Iterate through all seed values
+    for i in tqdm(range(seed_iterations), desc="Iterating seeds"):
+        # Convert seed into binary numpy arrya
+        hv_seed = numbin2list(i, seed_size)
+
+        # Decide whether iterative or hierarchical
+        if ca90_mode == "iter":
+            gen_hv = gen_hv_ca90_iterate_rows(hv_seed, hv_dim)
+        else:
+            gen_hv = gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim)
+
+        # Sum up to determine the density
+        density = np.sum(gen_hv)
+
+        # Append density score to the list
+        density_list.append(density)
+
+    # Find all those densities with 50%
+    # orthogonal values!
+    density_half_list = find_target_indices(density_list, half_dim)
+
+    return density_list, density_half_list
+
+
+# This function is for extracting seeds
+# That give the target 50% density of a base HV
+def extract_target_seeds(seed_size, seed_num, hv_dim, ca90_mode="iter"):
+    hv_half_dim = int(hv_dim / 2)
+    seed_list = []
+    seed_count = 0
+    run_count = 0
+
+    while seed_count != seed_num:
+        run_count += 1
+        hv_seed = gen_ri_hv(seed_size, 0.5)
+        if ca90_mode == "iter":
+            gen_hv = gen_hv_ca90_iterate_rows(hv_seed, hv_dim)
+        else:
+            gen_hv = gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim)
+
+        density_hv = np.sum(gen_hv)
+
+        if density_hv == hv_half_dim:
+            seed_idx = hvlist2num(hv_seed)
+            seed_list.append(seed_idx)
+            seed_count += 1
+
+    print(f"Search count time: {run_count}")
+    print(f"Target HV Dimension: {hv_dim}")
+    print(f"Seed size: {seed_size}")
+    print(f"Number of items: {seed_num}")
+
+    return seed_list
+
+
+"""
+    Main function list
+"""
+if __name__ == "__main__":
+    # Current test to test the extraction
+    # of target seeds for generating 50% density
+    seed_size = 16
+    seed_num = 20
+    hv_dim = 512
+    ca90_mode = "hier"
+    num_levels = 300
+
+    # Extract seed list
+    seed_list = extract_target_seeds(seed_size, seed_num, hv_dim, ca90_mode=ca90_mode)
+
+    # Use the first seed
+    hv_seed = numbin2list(seed_list[0], seed_size)
+
+    # Generate the orthogonal item memory
+    ortho_im = gen_orthogonal_im(num_levels, hv_dim, 0.5, hv_seed, im_type="random")
+
+    # Get the confusion matrix!
+    conf_mat = gen_conf_mat(num_levels, ortho_im)

--- a/hdc_exp/hdc_util.py
+++ b/hdc_exp/hdc_util.py
@@ -62,6 +62,18 @@ def extract_dataset(file_path):
             - hv_a: hypervecetor to binarize
             - threshold: threshold to set 1s for binary hv_type
             - hv_type: hv_type of hypervector, if bipolar we threshold at 0
+            
+    norm_dist_hv:
+        - for calculating the normalized distances
+        - arguments:
+            - hv_a, hv_b: input hypervectors
+            - hv_type: hv_type of hypervector, if bipolar we threshold at 0
+            
+    gen_conf_mat:
+        - for generating a confusion matrix
+        - arguments:
+            - num_levels: number of levels to generate
+            - hv_list: list of hypervectors to use
 
 """
 
@@ -134,6 +146,19 @@ def norm_dist_hv(hv_a, hv_b, hv_type="binary"):
         dist = 1 - (ham_dist / hv_a.size)
 
     return dist
+
+
+# Calculatiing confusion matrix
+def gen_conf_mat(num_levels, hv_list):
+    # Intiialize empty confusion matrix
+    conf_mat = np.zeros((num_levels, num_levels))
+
+    # Iterate through different levels
+    for i in range(num_levels):
+        for j in range(num_levels):
+            conf_mat[i][j] = norm_dist_hv(hv_list[i], hv_list[j])
+
+    return conf_mat
 
 
 """
@@ -271,7 +296,11 @@ def gen_orthogonal_im(
             
     measure_acc:
         - measures the accuracy between a test set and the correct set
-        - 
+        - arguments:
+            - assoc_mem: associative memory model
+            - predict_set: the set of qeury hvs
+            - correct_set: golden answers that need to match
+                           the predict_set
 """
 
 


### PR DESCRIPTION
This PR adds more experiments to explore the capabilities of the CA 90.

Major TODO:
- [x] Find seeds that generate 50% HV density
- [x] Develop tests to see how many combinations of seeds are possible
  - Note that the max seed size to simulate is 16 bits. If we go for 32-bits it will take forever.
  - However, it is possible to randomly generate for the case of 32 since several combinations exist. Then it's a matter of just selecting a few combinations.

Minor TODO:
- [x] Clean-up of some code
