### PR TITLE
Add multibank CA90 experiment and item memory

### DIFF
--- a/hdc_exp/hdc_util.py
+++ b/hdc_exp/hdc_util.py
@@ -10,6 +10,7 @@
 
 
 import numpy as np
+from tqdm import tqdm
 import matplotlib.pyplot as plt
 
 
@@ -154,7 +155,7 @@ def gen_conf_mat(num_levels, hv_list):
     conf_mat = np.zeros((num_levels, num_levels))
 
     # Iterate through different levels
-    for i in range(num_levels):
+    for i in tqdm(range(num_levels), desc="Generating confusion matrix"):
         for j in range(num_levels):
             conf_mat[i][j] = norm_dist_hv(hv_list[i], hv_list[j])
 
@@ -234,7 +235,7 @@ def gen_hv_ca90_iterate_rows(hv_seed, hv_dim):
 
 
 # Hierarchical generation of the ca90
-def gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim):
+def gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim, permute_base=1):
     # Initialize generated hv
     gen_hv = hv_seed
 
@@ -243,7 +244,7 @@ def gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim):
 
     # Iterate until we reach HV size
     while len_gen_hv != hv_dim:
-        gen_ca90_hv = gen_ca90(gen_hv, 1)
+        gen_ca90_hv = gen_ca90(gen_hv, permute_base)
         gen_hv = np.concatenate((gen_hv, gen_ca90_hv))
         len_gen_hv = len(gen_hv)
 
@@ -252,7 +253,7 @@ def gen_hv_ca90_hierarchical_rows(hv_seed, hv_dim):
 
 # Generating orthogonal item memory
 def gen_orthogonal_im(
-    num_hv, hv_dim, p_dense, hv_seed, hv_type="binary", im_type="random"
+    num_hv, hv_dim, p_dense, hv_seed, permute_base=1, hv_type="binary", im_type="random"
 ):
     # Initialize empty matrix
     orthogonal_im = gen_empty_mem_hv(num_hv, hv_dim)
@@ -272,7 +273,7 @@ def gen_orthogonal_im(
                 hv_dim=hv_dim, p_dense=p_dense, hv_type=hv_type
             )
         else:
-            orthogonal_im[i] = gen_ca90(orthogonal_im[i - 1], 1)
+            orthogonal_im[i] = gen_ca90(orthogonal_im[i - 1], permute_base)
 
     return orthogonal_im
 
@@ -421,4 +422,29 @@ def simple_plot2d(
         # Show plot
         plt.show()
 
+    return
+
+
+# Plotting heatmaps
+
+
+def heatmap_plot(
+    data,
+    title="Cool title",
+    xlabel="x-axis",
+    ylabel="y-axis",
+):
+    # Heatmap
+    plt.imshow(data, cmap="hot", interpolation="nearest")
+
+    # Add colorbar
+    plt.colorbar()
+
+    # Add title and axes titles
+    plt.title(title)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+    # Step 4: Display the plot
+    plt.show()
     return

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyright
 flake8
 numpy
 matplotlib
+tqdm

--- a/rtl/item_memory/ca90_hier_base.sv
+++ b/rtl/item_memory/ca90_hier_base.sv
@@ -1,0 +1,88 @@
+
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: CA90 Item Memory Hierarchical Base
+// Description:
+// This is a template to generate the CA90
+// base HV. A template is needed due to SV limitations.
+//---------------------------
+
+module ca90_hier_base #(
+  parameter int unsigned HVDimension = 512,
+  parameter int unsigned SeedWidth   = 32
+)(
+  // Inputs
+  input  logic [  SeedWidth-1:0] seed_hv_i,
+  output logic [HVDimension-1:0] base_hv_o
+);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic [31:0] ca90_layer_out_0;
+  logic [63:0] ca90_layer_out_1;
+  logic [127:0] ca90_layer_out_2;
+  logic [255:0] ca90_layer_out_3;
+
+  logic [63:0] ca90_layer_in_1;
+  logic [127:0] ca90_layer_in_2;
+  logic [255:0] ca90_layer_in_3;
+
+  //---------------------------
+  // Wiring concatenation
+  //---------------------------
+    assign ca90_layer_in_1 = {ca90_layer_out_0, seed_hv_i};
+    assign ca90_layer_in_2 = {ca90_layer_out_1, ca90_layer_in_1};
+    assign ca90_layer_in_3 = {ca90_layer_out_2, ca90_layer_in_2};
+
+  //---------------------------
+  // CA 90 modules
+  //---------------------------
+
+  ca90_unit #(
+    .Dimension   ( 32 )
+  ) i_ca90_im_0 (
+    .vector_i    (        seed_hv_i ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_0 )
+  );
+
+  ca90_unit #(
+    .Dimension   ( 64 )
+  ) i_ca90_im_1 (
+    .vector_i    (  ca90_layer_in_1 ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_1 )
+  );
+
+  ca90_unit #(
+    .Dimension   ( 128 )
+  ) i_ca90_im_2 (
+    .vector_i    (  ca90_layer_in_2 ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_2 )
+  );
+
+  ca90_unit #(
+    .Dimension   ( 256 )
+  ) i_ca90_im_3 (
+    .vector_i    (  ca90_layer_in_3 ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_3 )
+  );
+
+  //---------------------------
+  // Concatenating for output
+  //---------------------------
+
+  assign base_hv_o = {
+    ca90_layer_out_3,
+    ca90_layer_out_2,
+    ca90_layer_out_1,
+    ca90_layer_out_0,
+    seed_hv_i
+  };
+
+endmodule

--- a/rtl/item_memory/ca90_item_memory.sv
+++ b/rtl/item_memory/ca90_item_memory.sv
@@ -5,43 +5,81 @@
 // Module: CA90 Item Memory
 // Description:
 // This is the base CA90 item memory
+// Note that this item memory
+// will be a bit more customized and less
+// flexible. Only the dimension size can change.
+//
+// Because of the CA90 limitations despite being
+// a good compressive mechanism, we need to generate
+// 8 item memories to generate 1024 cases
+//
+// Therevore we need 8 different seeds for this!
 //---------------------------
 
 module ca90_item_memory #(
   parameter int unsigned HVDimension   = 512,
-  parameter int unsigned NumImElements = 1024,
+  parameter int unsigned NumTotIm      = 1024,
+  parameter int unsigned NumPerImBank  = 128,
   // Don't touch parameters
-  parameter int unsigned ImSelWidth    = $clog2(NumImElements)
+  parameter int unsigned Ca90ImPerm    = 7,
+  parameter int unsigned SeedWidth     = 32,
+  parameter int unsigned NumImSets     = NumTotIm/NumPerImBank,
+  parameter int unsigned ImSelWidth    = $clog2(NumTotIm)
 )(
   // Inputs
-  input  logic [HVDimension-1:0] seed_hv_i,
+  input  logic [  NumImSets-1:0][SeedWidth-1:0] seed_hv_i,
   input  logic [ ImSelWidth-1:0] im_sel_a_i,
   input  logic [ ImSelWidth-1:0] im_sel_b_i,
   // Outputs
   output logic [HVDimension-1:0] im_a_o,
   output logic [HVDimension-1:0] im_b_o
 );
+  //---------------------------
+  // Some working variable
+  //---------------------------
+  genvar i, j;
 
   //---------------------------
   // Wires
   //---------------------------
-  logic [NumImElements-1:0][HVDimension-1:0] item_memory;
-
-  assign item_memory[0] = seed_hv_i;
+  logic [NumTotIm-1:0][HVDimension-1:0] item_memory;
+  logic [NumImSets-1:0][NumPerImBank-1:0][HVDimension-1:0] item_memory_bases;
 
   //---------------------------
-  // Generate item memory HVs with CA90
+  // Base Item Memory
   //---------------------------
-  genvar i;
-  for (i=0; i < NumImElements-1; i=i+1) begin: gen_item_hvs
-    ca90_unit #(
-      .Dimension   (      HVDimension )
-    ) i_ca90_im_hv (
-      .vector_i    (   item_memory[i] ),
-      .shift_amt_i (                1 ),
-      .vector_o    ( item_memory[i+1] )
+  for ( i = 0; i < NumImSets; i++) begin: gen_per_im_set
+
+    // First generate the base
+    ca90_hier_base #(
+      .HVDimension ( HVDimension    ),
+      .SeedWidth   ( SeedWidth      )
+    ) i_ca90_hier_base (
+      .seed_hv_i   ( seed_hv_i[i]            ),
+      .base_hv_o   ( item_memory_bases[i][0] )
     );
+
+    // Generate IM set with all other bases
+    for ( j = 0; j < NumPerImBank-1; j++) begin: gen_per_im_bank
+      ca90_unit #(
+        .Dimension   (               HVDimension )
+      ) i_ca90_im_hv (
+        .vector_i    (   item_memory_bases[i][j] ),
+        .shift_amt_i (                Ca90ImPerm ),
+        .vector_o    ( item_memory_bases[i][j+1] )
+      );
+
+    end
   end
+
+  always_comb begin
+    for ( int i = 0; i < NumImSets; i++) begin
+      for ( int j = 0; j < NumPerImBank; j++) begin
+        item_memory[i*NumPerImBank+j] = item_memory_bases[i][j];
+      end
+    end
+  end
+
 
   //---------------------------
   // Read output ports

--- a/rtl/templates/ca90_hier_base.sv.tpl
+++ b/rtl/templates/ca90_hier_base.sv.tpl
@@ -1,0 +1,84 @@
+<%
+  import math
+
+  num_hier_layers = int(math.log2(cfg["hv_dim"]/cfg["seed_dim"]))
+
+  print(num_hier_layers)
+%>
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: CA90 Item Memory Hierarchical Base
+// Description:
+// This is a template to generate the CA90
+// base HV. A template is needed due to SV limitations.
+//---------------------------
+
+module ca90_hier_base #(
+  parameter int unsigned HVDimension = ${cfg["hv_dim"]},
+  parameter int unsigned SeedWidth   = ${cfg["seed_dim"]}
+)(
+  // Inputs
+  input  logic [  SeedWidth-1:0] seed_hv_i,
+  output logic [HVDimension-1:0] base_hv_o
+);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+% for i in range(0,num_hier_layers):
+  logic [${cfg["seed_dim"]*(2**i)-1}:0] ca90_layer_out_${i};
+% endfor
+
+% for i in range(1,num_hier_layers):
+  logic [${cfg["seed_dim"]*(2**i)-1}:0] ca90_layer_in_${i};
+% endfor
+
+  //---------------------------
+  // Wiring concatenation
+  //---------------------------
+% for i in range(1,num_hier_layers):
+  % if i == 1:
+    assign ca90_layer_in_${i} = {ca90_layer_out_${i-1}, seed_hv_i};
+  % else:
+    assign ca90_layer_in_${i} = {ca90_layer_out_${i-1}, ca90_layer_in_${i-1}};
+  % endif
+% endfor
+
+  //---------------------------
+  // CA 90 modules
+  //---------------------------
+
+% for i in range(0,num_hier_layers):
+  % if i == 0:
+  ca90_unit #(
+    .Dimension   ( ${cfg["seed_dim"]*(2**i)} )
+  ) i_ca90_im_${i} (
+    .vector_i    (        seed_hv_i ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_${i} )
+  );
+  % else:
+  ca90_unit #(
+    .Dimension   ( ${cfg["seed_dim"]*(2**i)} )
+  ) i_ca90_im_${i} (
+    .vector_i    (  ca90_layer_in_${i} ),
+    .shift_amt_i (                1 ),
+    .vector_o    ( ca90_layer_out_${i} )
+  );
+  % endif
+
+% endfor
+  //---------------------------
+  // Concatenating for output
+  //---------------------------
+
+  assign base_hv_o = {
+% for i in range(0, num_hier_layers):
+    ca90_layer_out_${num_hier_layers-i-1},
+% endfor
+    seed_hv_i
+  };
+
+endmodule

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -16,7 +16,9 @@ SEED_DIM = 64
 REG_FILE_WIDTH = 32
 
 # Item memory parameters
-NUM_ORTHO_ITEMS = 256
+NUM_TOT_IM = 256
+NUM_PER_IM_BANK = int(HV_DIM // 4)
+CA90_MODE = "ca90_hier"
 
 # Encoder parameters
 BUNDLER_COUNT_WIDTH = 8

--- a/tests/test_ca90_item_memory.py
+++ b/tests/test_ca90_item_memory.py
@@ -13,13 +13,15 @@ from cocotb.triggers import Timer
 import pytest
 import sys
 
-from util import get_root, setup_and_run, check_result_array, numbin2list, hvlist2num
+from util import get_root, setup_and_run, check_result_array, numbin2list
 
 # Add hdc utility functions
 hdc_util_path = get_root() + "/hdc_exp/"
 sys.path.append(hdc_util_path)
 
-from hdc_util import gen_orthogonal_im, gen_ri_hv  # noqa: E402
+# Grab the CA90 generation from the
+# cellular automata experiment set
+from cellular_automata import gen_ca90_im_set  # noqa: E402
 
 
 @cocotb.test()
@@ -28,30 +30,45 @@ async def ca90_item_memory_dut(dut):
     cocotb.log.info("         Testing CA90 Item Memory           ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Get nice seed with 50% 1s and 0s
-    seed_hv_list = gen_ri_hv(set_parameters.HV_DIM, 0.5)
-    seed_hv = hvlist2num(seed_hv_list)
+    # For parameter checking, we put a warning
+    if set_parameters.NUM_PER_IM_BANK >= int(set_parameters.HV_DIM / 2):
+        cocotb.log.info(" ------------------------------------------ ")
+        cocotb.log.info("            !!!!!  WARNING  !!!!!           ")
+        cocotb.log.info(f" The number of IM per bank {set_parameters.NUM_PER_IM_BANK}")
+        cocotb.log.info(
+            f" must be less than half of the HV dimension size {set_parameters.HV_DIM}"
+        )
+        cocotb.log.info(
+            " It is recommended that it is 1/4th of the dimension size to avoid"
+        )
+        cocotb.log.info(" saturating at all 1s or all 0s due to CA90 limitations")
+        cocotb.log.info(" ------------------------------------------ ")
 
-    cocotb.log.info(f"Working with seed: {seed_hv}")
-
-    # Generate golden item memory
-    golden_im = gen_orthogonal_im(
-        set_parameters.NUM_ORTHO_ITEMS,
-        set_parameters.HV_DIM,
-        0.5,
-        seed_hv_list,
-        hv_type="binary",
-        im_type="ca90_iter",
+    # Generate seed list and golden IM
+    seed_list, golden_im, conf_mat = gen_ca90_im_set(
+        seed_size=set_parameters.REG_FILE_WIDTH,
+        hv_dim=set_parameters.HV_DIM,
+        num_total_im=set_parameters.NUM_TOT_IM,
+        num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        ca90_mode=set_parameters.CA90_MODE,
     )
 
-    # Dummy seed value
-    dut.seed_hv_i.value = seed_hv
+    # For combining into a single
+    # wire bus for simulation purposes
+    num_im_banks = int(set_parameters.NUM_TOT_IM / set_parameters.NUM_PER_IM_BANK)
+    seed_input = 0
+    for i in range(num_im_banks):
+        seed_input = (seed_input << set_parameters.REG_FILE_WIDTH) + seed_list[
+            num_im_banks - i - 1
+        ]
+
+    dut.seed_hv_i.value = seed_input
 
     # Propagate time for logic
     await Timer(1, units="ps")
 
     # Load request, propagate, check result
-    for i in range(set_parameters.NUM_ORTHO_ITEMS):
+    for i in range(set_parameters.NUM_TOT_IM):
         dut.im_sel_a_i.value = i
         dut.im_sel_b_i.value = i
         await Timer(1, units="ps")
@@ -81,13 +98,15 @@ async def ca90_item_memory_dut(dut):
     [
         {
             "HVDimension": str(set_parameters.HV_DIM),
-            "NumImElements": str(set_parameters.NUM_ORTHO_ITEMS),
+            "NumTotIm": str(set_parameters.NUM_TOT_IM),
+            "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
         }
     ],
 )
 def test_ca90_item_memory(simulator, parameters):
     verilog_sources = [
         "/rtl/item_memory/ca90_unit.sv",
+        "/rtl/item_memory/ca90_hier_base.sv",
         "/rtl/item_memory/ca90_item_memory.sv",
     ]
 
@@ -101,5 +120,4 @@ def test_ca90_item_memory(simulator, parameters):
         module=module,
         simulator=simulator,
         parameters=parameters,
-        waves=True,
     )

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,10 +11,8 @@
 import random
 import os
 import cocotb
-import hjson
 from mako.template import Template
 from mako.lookup import TemplateLookup
-import JsonRef
 from cocotb_test.simulator import run
 from cocotb.triggers import Timer, RisingEdge
 import numpy as np
@@ -77,17 +75,6 @@ def setup_and_run(
         waves=waves,
         parameters=parameters,
     )
-
-
-# Extract json file
-def get_config(cfg_path: str):
-    with open(cfg_path, "r") as jsonf:
-        srcfull = jsonf.read()
-
-    # Format hjson file
-    cfg = hjson.loads(srcfull, use_decimal=True)
-    cfg = JsonRef.replace_refs(cfg)
-    return cfg
 
 
 # Read template


### PR DESCRIPTION
This PR adds the multi-bank CA90 experiment, generation, and item memory file. It contains several components:

Major TODO:
- [x] Add experiment to see if CA90 in multi banks generates nice orthogonality
- [x] Add generation for the CA90 hierarchical base HV due to SV limitations
- [x] Add template for base generation
- [x] Add the generated file
- [x] Update ca90 test simulation
- [x] Import the ca90 experiment into the test simulation