### PR TITLE
Add combined item memory

### DIFF
--- a/rtl/common/mux.sv
+++ b/rtl/common/mux.sv
@@ -1,0 +1,23 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: MUX
+// Description:
+// A simple MUX with variable size
+//---------------------------
+
+module mux #(
+  parameter int unsigned DataWidth   = 32,
+  parameter int unsigned NumSel      = 4,
+  // Don't touch!
+  parameter int unsigned NumSelWidth = $clog2(NumSel)
+)(
+  input  logic             [NumSelWidth-1:0] sel_i,
+  input  logic [NumSel-1:0][  DataWidth-1:0] signal_i,
+  output logic             [  DataWidth-1:0] signal_o
+);
+
+  assign signal_o = signal_i[sel_i];
+
+endmodule

--- a/rtl/item_memory/ca90_item_memory.sv
+++ b/rtl/item_memory/ca90_item_memory.sv
@@ -20,9 +20,9 @@ module ca90_item_memory #(
   parameter int unsigned HVDimension   = 512,
   parameter int unsigned NumTotIm      = 1024,
   parameter int unsigned NumPerImBank  = 128,
+  parameter int unsigned SeedWidth     = 32,
   // Don't touch parameters
   parameter int unsigned Ca90ImPerm    = 7,
-  parameter int unsigned SeedWidth     = 32,
   parameter int unsigned NumImSets     = NumTotIm/NumPerImBank,
   parameter int unsigned ImSelWidth    = $clog2(NumTotIm)
 )(

--- a/rtl/item_memory/cim.sv
+++ b/rtl/item_memory/cim.sv
@@ -2,24 +2,18 @@
 // Copyright 2024 KU Leuven
 // Ryan Antonio <ryan.antonio@esat.kuleuven.be>
 //
-// Module: CA90 Item Memory
+// Module: Continuous Item Memory (CiM)
 // Description:
-// This is the base CA90 item memory
-// Note that this item memory
-// will be a bit more customized and less
-// flexible. Only the dimension size can change.
-//
-// Because of the CA90 limitations despite being
-// a good compressive mechanism, we need to generate
-// 8 item memories to generate 1024 cases
-//
-// Therevore we need 8 different seeds for this!
+// This is the CiM used to represent
+// real values signals. It generates a
+// square CiM which is at max half
+// of the specified working dimension
 //---------------------------
 
 module cim #(
   parameter int unsigned HVDimension   = 512,
-  // Don't touch parameters
   parameter int unsigned SeedWidth     = 32,
+  // Don't touch parameters
   parameter int unsigned NumCimLevels  = HVDimension/2,
   parameter int unsigned ImSelWidth    = $clog2(NumCimLevels)
 )(

--- a/rtl/item_memory/cim_bit_flip.sv
+++ b/rtl/item_memory/cim_bit_flip.sv
@@ -1,3 +1,16 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: CiM Bit Flip
+// Description:
+// A dedicated module to cut SV limitations
+// on signal loop banks.
+//
+// This statically flips the bit based on
+// the FlipBitPos value
+//---------------------------
+
 module cim_bit_flip #(
   parameter int unsigned HVDimension = 512,
   parameter int unsigned FlipBitPos  = 1

--- a/rtl/item_memory/item_memory.sv
+++ b/rtl/item_memory/item_memory.sv
@@ -1,0 +1,133 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: CA90 Item Memory
+// Description:
+// This is the main item memory block
+// It consists of both the CiM and CA90
+// with control ports that are used to select
+// the IM addresses and whether it gets
+// from CiM or from the CA 90
+//---------------------------
+
+module item_memory #(
+  parameter int unsigned HVDimension = 512,
+  parameter int unsigned NumTotIm    = 1024,
+  parameter int unsigned NumPerImBank= 128,
+  parameter int unsigned ImAddrWidth = 32,
+  parameter int unsigned SeedWidth   = 32,
+  // Don't touch!
+  parameter int unsigned NumImSets   = NumTotIm/NumPerImBank
+)(
+  input  logic                                  port_a_cim,
+  input  logic                [  SeedWidth-1:0] cim_seed_hv,
+  input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv,
+  input  logic                [ImAddrWidth-1:0] im_a_addr_i,
+  input  logic                [ImAddrWidth-1:0] im_b_addr_i,
+  output logic                [HVDimension-1:0] im_a_o,
+  output logic                [HVDimension-1:0] im_b_o
+);
+
+  //---------------------------
+  // Local parameters
+  //---------------------------
+  localparam int unsigned NumCimLevels = HVDimension/2;
+  localparam int unsigned CimSelWidth  = $clog2(NumCimLevels);
+  localparam int unsigned ImSelWidth   = $clog2(NumTotIm);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic [HVDimension-1:0] cim_a;
+  logic [HVDimension-1:0] im_a;
+
+  logic [1:0][HVDimension-1:0] mux_porta_out_in;
+
+  logic [1:0][CimSelWidth-1:0] mux_cim_addr_in;
+  logic      [CimSelWidth-1:0] mux_cim_addr_out;
+
+
+  logic [1:0][ ImSelWidth-1:0] mux_im_addr_in;
+  logic      [ ImSelWidth-1:0] mux_im_addr_out;
+
+  //---------------------------
+  // Input MUX for CiM
+  //---------------------------
+  assign mux_cim_addr_in = {
+    im_a_addr_i[CimSelWidth-1:0],
+    {CimSelWidth{1'b0}}
+  };
+
+  mux #(
+    .DataWidth  ( CimSelWidth       ),
+    .NumSel     ( 2                 )
+  ) i_mux_cim_in (
+    .sel_i      ( port_a_cim        ),
+    .signal_i   ( mux_cim_addr_in   ),
+    .signal_o   ( mux_cim_addr_out  )
+  );
+
+  //---------------------------
+  // CiM Module
+  //---------------------------
+  cim #(
+    .HVDimension ( HVDimension      ),
+    .SeedWidth   ( SeedWidth        )
+  ) i_cim (
+    .seed_hv_i   ( cim_seed_hv      ),
+    .cim_sel_i   ( mux_cim_addr_out ),
+    .cim_o       ( cim_a            )
+  );
+
+  //---------------------------
+  // Input MUX for iM
+  //---------------------------
+  assign mux_im_addr_in = {
+    {ImSelWidth{1'b0}},
+    im_a_addr_i[ImSelWidth-1:0]
+  };
+
+  mux #(
+    .DataWidth  ( ImSelWidth      ),
+    .NumSel     ( 2               )
+  ) i_mux_im_in (
+    .sel_i      ( port_a_cim      ),
+    .signal_i   ( mux_im_addr_in  ),
+    .signal_o   ( mux_im_addr_out )
+  );
+
+  //---------------------------
+  // CA90 iM Module
+  //---------------------------
+  ca90_item_memory #(
+    .HVDimension  ( HVDimension     ),
+    .NumTotIm     ( NumTotIm        ),
+    .NumPerImBank ( NumPerImBank    ),
+    .SeedWidth    ( SeedWidth       )
+  ) i_ca90_item_memory (
+    .seed_hv_i    ( im_seed_hv      ),
+    .im_sel_a_i   ( mux_im_addr_out ),
+    .im_sel_b_i   ( im_b_addr_i     ),
+    .im_a_o       ( im_a            ),
+    .im_b_o       ( im_b_o          )
+  );
+
+  //---------------------------
+  // Output MUX
+  //---------------------------
+  assign mux_porta_out_in = {
+    cim_a,
+    im_a
+  };
+
+  mux #(
+    .DataWidth  ( HVDimension      ),
+    .NumSel     ( 2                )
+  ) i_mux_porta_out (
+    .sel_i      ( port_a_cim       ),
+    .signal_i   ( mux_porta_out_in ),
+    .signal_o   ( im_a_o           )
+  );
+
+endmodule

--- a/tests/test_item_memory.py
+++ b/tests/test_item_memory.py
@@ -1,0 +1,192 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the combined item memory
+  that contains both the CiM and CA90
+"""
+
+import set_parameters
+import cocotb
+from cocotb.triggers import Timer
+import pytest
+import sys
+
+from util import get_root, setup_and_run, check_result_array, numbin2list
+
+# Add hdc utility functions
+hdc_util_path = get_root() + "/hdc_exp/"
+sys.path.append(hdc_util_path)
+
+# Grab the CA90 generation from the
+# cellular automata experiment set
+from cellular_automata import gen_ca90_im_set  # noqa: E402
+
+# Grab the CiM generation from the utility
+from hdc_util import gen_square_cim  # noqa: E402
+
+
+@cocotb.test()
+async def item_memory_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("                Item Memory                 ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # For parameter checking, we put a warning
+    if set_parameters.NUM_PER_IM_BANK >= int(set_parameters.HV_DIM / 2):
+        cocotb.log.info(" ------------------------------------------ ")
+        cocotb.log.info("            !!!!!  WARNING  !!!!!           ")
+        cocotb.log.info(f" The number of IM per bank {set_parameters.NUM_PER_IM_BANK}")
+        cocotb.log.info(
+            f" must be less than half of the HV dimension size {set_parameters.HV_DIM}"
+        )
+        cocotb.log.info(
+            " It is recommended that it is 1/4th of the dimension size to avoid"
+        )
+        cocotb.log.info(" saturating at all 1s or all 0s due to CA90 limitations")
+        cocotb.log.info(" ------------------------------------------ ")
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("     Generate Seeds and Golden Values       ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # This is for the seed input
+    cim_seed_input = 3275349888
+
+    # Convert to list for golden checking
+    cim_seed_input_list = numbin2list(cim_seed_input, set_parameters.REG_FILE_WIDTH)
+
+    # Generated golden CiM
+    golden_cim = gen_square_cim(
+        set_parameters.HV_DIM, cim_seed_input_list, im_type=set_parameters.CA90_MODE
+    )
+
+    # Generate seed list and golden IM
+    im_seed_input_list, golden_im, conf_mat = gen_ca90_im_set(
+        seed_size=set_parameters.REG_FILE_WIDTH,
+        hv_dim=set_parameters.HV_DIM,
+        num_total_im=set_parameters.NUM_TOT_IM,
+        num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        ca90_mode=set_parameters.CA90_MODE,
+    )
+
+    # For combining into a single
+    # wire bus for simulation purposes
+    num_im_banks = int(set_parameters.NUM_TOT_IM / set_parameters.NUM_PER_IM_BANK)
+    im_seed_input = 0
+    for i in range(num_im_banks):
+        im_seed_input = (
+            im_seed_input << set_parameters.REG_FILE_WIDTH
+        ) + im_seed_input_list[num_im_banks - i - 1]
+
+    # Input the CiM seed and the iM seeds
+    dut.cim_seed_hv.value = cim_seed_input
+    dut.im_seed_hv.value = im_seed_input
+
+    # Initialize all other ports to 0
+    dut.port_a_cim.value = 0
+    dut.im_a_addr_i.value = 0
+    dut.im_b_addr_i.value = 0
+
+    # Propagate time for logic
+    await Timer(1, units="ps")
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         Checking CA90 Item Memory          ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Since port_a_cim is 0, it selects the
+    # CA90 item memory
+
+    # Load request, propagate, check result
+    for i in range(set_parameters.NUM_TOT_IM):
+        dut.im_a_addr_i.value = i
+        dut.im_b_addr_i.value = i
+        await Timer(1, units="ps")
+
+        actual_val_a = dut.im_a_o.value.integer
+        actual_val_b = dut.im_b_o.value.integer
+
+        # Convert actual values to binary list
+        actual_val_a = numbin2list(actual_val_a, set_parameters.HV_DIM)
+        actual_val_b = numbin2list(actual_val_b, set_parameters.HV_DIM)
+
+        # Check arrays if they are equal
+        # Unfortunately, this is needed because there are
+        # bit-width limitations for integer conversions
+        check_result_array(actual_val_a, golden_im[i])
+        check_result_array(actual_val_b, golden_im[i])
+
+    # Clear other inputs but put
+    # port_a_cim to 1 to select the CiM
+    dut.port_a_cim.value = 1
+    dut.im_a_addr_i.value = 0
+    dut.im_b_addr_i.value = 0
+
+    # Propagate time for logic
+    await Timer(1, units="ps")
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("               Checking CiM                 ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Use select and check for values
+    num_cim_levels = int(set_parameters.HV_DIM / 2)
+
+    for i in range(num_cim_levels):
+        # Input the selection
+        dut.im_a_addr_i.value = i
+
+        # Propagate time for logic
+        await Timer(1, units="ps")
+
+        # Obtain actual value
+        actual_val_a = dut.im_a_o.value.integer
+        actual_val_a = numbin2list(actual_val_a, set_parameters.HV_DIM)
+
+        # Compare to golden
+        check_result_array(actual_val_a, golden_cim[i])
+
+    # This is for waveform checking later
+    for i in range(set_parameters.TEST_RUNS):
+        # Propagate time for logic
+        await Timer(1, units="ps")
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "HVDimension": str(set_parameters.HV_DIM),
+            "NumTotIm": str(set_parameters.NUM_TOT_IM),
+            "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
+            "ImAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            "SeedWidth": str(set_parameters.REG_FILE_WIDTH),
+        }
+    ],
+)
+def test_item_memory(simulator, parameters):
+    verilog_sources = [
+        "/rtl/common/mux.sv",
+        "/rtl/item_memory/ca90_unit.sv",
+        "/rtl/item_memory/ca90_hier_base.sv",
+        "/rtl/item_memory/cim_bit_flip.sv",
+        "/rtl/item_memory/cim.sv",
+        "/rtl/item_memory/ca90_item_memory.sv",
+        "/rtl/item_memory/item_memory.sv",
+    ]
+
+    toplevel = "item_memory"
+
+    module = "test_item_memory"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=True,
+    )


### PR DESCRIPTION
This PR combines both the CiM and CA90 item memories with ports for seeds and CiM or iM switcher for port A.

Major TODO:
- [x] Create item memory
  - [x] Add the CiM
  - [x] Add the iM (CA90)
- [x] Test for item memory