### PR TITLE
Combine item memory into HV encoder

### DIFF
--- a/rtl/hv_encoder.sv
+++ b/rtl/hv_encoder.sv
@@ -11,6 +11,10 @@
 
 module hv_encoder #(
   parameter int unsigned HVDimension    = 512,
+  parameter int unsigned NumTotIm       = 1024,
+  parameter int unsigned NumPerImBank   = 128,
+  parameter int unsigned ImAddrWidth    = 32,
+  parameter int unsigned SeedWidth      = 32,
   parameter int unsigned BundCountWidth = 8,
   parameter int unsigned BundMuxWidth   = 2,
   parameter int unsigned ALUMuxWidth    = 2,
@@ -19,45 +23,53 @@ module hv_encoder #(
   parameter int unsigned QvMuxWidth     = 2,
   parameter int unsigned RegNum         = 4,
   // Don't touch!
+  parameter int unsigned NumImSets      = NumTotIm/NumPerImBank,
   parameter int unsigned NumALUOps      = 4,
   parameter int unsigned ALUOpsWidth    = $clog2(NumALUOps     ),
   parameter int unsigned ShiftWidth     = $clog2(ALUMaxShiftAmt),
   parameter int unsigned RegAddrWidth   = $clog2(RegNum        )
 )(
   // Clocks and reset
-  input  logic clk_i,
-  input  logic rst_ni,
-  // Item memory inputs
-  input  logic [ HVDimension-1:0] im_rd_a_i,
-  input  logic [ HVDimension-1:0] im_rd_b_i,
+  input  logic                                   clk_i,
+  input  logic                                   rst_ni,
+  // Item address inputs
+  input  logic                [ ImAddrWidth-1:0] im_a_addr_i,
+  input  logic                [ ImAddrWidth-1:0] im_b_addr_i,
+  // Control ports for item memory
+  input  logic                                   port_a_cim_i,
+  input  logic                [   SeedWidth-1:0] cim_seed_hv_i,
+  input  logic [NumImSets-1:0][   SeedWidth-1:0] im_seed_hv_i,
   // Control ports for ALU
-  input  logic [ ALUMuxWidth-1:0] alu_mux_a_i,
-  input  logic [ ALUMuxWidth-1:0] alu_mux_b_i,
-  input  logic [ ALUOpsWidth-1:0] alu_ops_i,
-  input  logic [  ShiftWidth-1:0] alu_shift_amt_i,
+  input  logic                [ ALUMuxWidth-1:0] alu_mux_a_i,
+  input  logic                [ ALUMuxWidth-1:0] alu_mux_b_i,
+  input  logic                [ ALUOpsWidth-1:0] alu_ops_i,
+  input  logic                [  ShiftWidth-1:0] alu_shift_amt_i,
   // Control ports for bundlers
-  input  logic [BundMuxWidth-1:0] bund_mux_a_i,
-  input  logic [BundMuxWidth-1:0] bund_mux_b_i,
-  input  logic                    bund_valid_a_i,
-  input  logic                    bund_valid_b_i,
-  input  logic                    bund_clr_a_i,
-  input  logic                    bund_clr_b_i,
+  input  logic                [BundMuxWidth-1:0] bund_mux_a_i,
+  input  logic                [BundMuxWidth-1:0] bund_mux_b_i,
+  input  logic                                   bund_valid_a_i,
+  input  logic                                   bund_valid_b_i,
+  input  logic                                   bund_clr_a_i,
+  input  logic                                   bund_clr_b_i,
   // Control ports for register ops
-  input  logic [ RegMuxWidth-1:0] reg_mux_i,
-  input  logic [RegAddrWidth-1:0] reg_rd_addr_a_i,
-  input  logic [RegAddrWidth-1:0] reg_rd_addr_b_i,
-  input  logic [RegAddrWidth-1:0] reg_wr_addr_i,
-  input  logic                    reg_wr_en_i,
+  input  logic                [ RegMuxWidth-1:0] reg_mux_i,
+  input  logic                [RegAddrWidth-1:0] reg_rd_addr_a_i,
+  input  logic                [RegAddrWidth-1:0] reg_rd_addr_b_i,
+  input  logic                [RegAddrWidth-1:0] reg_wr_addr_i,
+  input  logic                                   reg_wr_en_i,
   // Control ports for query HV
-  input  logic                    qhv_clr_i,
-  input  logic                    qhv_wen_i,
-  input  logic [  QvMuxWidth-1:0] qhv_mux_i,
-  output logic [ HVDimension-1:0] qhv_o
+  input  logic                                   qhv_clr_i,
+  input  logic                                   qhv_wen_i,
+  input  logic                [  QvMuxWidth-1:0] qhv_mux_i,
+  output logic                [ HVDimension-1:0] qhv_o
 );
 
   //---------------------------
   // Wires
   //---------------------------
+  logic [HVDimension-1:0] im_a;
+  logic [HVDimension-1:0] im_b;
+
   logic [HVDimension-1:0] reg_wr_data;
   logic [HVDimension-1:0] reg_rd_data_a;
   logic [HVDimension-1:0] reg_rd_data_b;
@@ -74,17 +86,36 @@ module hv_encoder #(
   logic [HVDimension-1:0] qhv_input;
   logic [HVDimension-1:0] qhv_output;
 
+
+  //---------------------------
+  // Item memory
+  //---------------------------
+  item_memory #(
+    .HVDimension    ( HVDimension   ),
+    .NumTotIm       ( NumTotIm      ),
+    .NumPerImBank   ( NumPerImBank  ),
+    .ImAddrWidth    ( ImAddrWidth   ),
+    .SeedWidth      ( SeedWidth     )
+  ) i_item_memory (
+    .port_a_cim_i   ( port_a_cim_i  ),
+    .cim_seed_hv_i  ( cim_seed_hv_i ),
+    .im_seed_hv_i   ( im_seed_hv_i  ),
+    .im_a_addr_i    ( im_a_addr_i   ),
+    .im_b_addr_i    ( im_b_addr_i   ),
+    .im_a_o         ( im_a          ),
+    .im_b_o         ( im_b          )
+  );
+
   //---------------------------
   // HV register file MUX
   //---------------------------
   always_comb begin
     case ( reg_mux_i )
-      2'b01:   reg_wr_data = im_rd_a_i;
+      2'b01:   reg_wr_data = im_a;
       2'b10:   reg_wr_data = bund_output_a;
       2'b11:   reg_wr_data = bund_output_b;
       default: reg_wr_data = alu_output;
     endcase
-
   end
 
   //---------------------------
@@ -118,7 +149,7 @@ module hv_encoder #(
       2'b01:   alu_input_a = reg_rd_data_a;
       2'b10:   alu_input_a = bund_output_a;
       2'b11:   alu_input_a = bund_output_b;
-      default: alu_input_a = im_rd_a_i;
+      default: alu_input_a = im_a;
     endcase
 
     // For port B
@@ -126,7 +157,7 @@ module hv_encoder #(
       2'b01:   alu_input_b = reg_rd_data_b;
       2'b10:   alu_input_b = bund_output_a;
       2'b11:   alu_input_b = bund_output_b;
-      default: alu_input_b = im_rd_b_i;
+      default: alu_input_b = im_b;
     endcase
   end
 
@@ -155,7 +186,7 @@ module hv_encoder #(
     // For bundler A
     case ( bund_mux_a_i )
       2'b01:   bund_input_a = bund_output_b;
-      2'b10:   bund_input_a = im_rd_a_i;
+      2'b10:   bund_input_a = im_a;
       2'b11:   bund_input_a = reg_rd_data_a;
       default: bund_input_a = alu_output;
     endcase
@@ -163,7 +194,7 @@ module hv_encoder #(
     // For bundler B
     case ( bund_mux_b_i )
       2'b01:   bund_input_b = bund_output_a;
-      2'b10:   bund_input_b = im_rd_a_i;
+      2'b10:   bund_input_b = im_a;
       2'b11:   bund_input_b = reg_rd_data_a;
       default: bund_input_b = alu_output;
     endcase

--- a/rtl/item_memory/item_memory.sv
+++ b/rtl/item_memory/item_memory.sv
@@ -20,9 +20,9 @@ module item_memory #(
   // Don't touch!
   parameter int unsigned NumImSets   = NumTotIm/NumPerImBank
 )(
-  input  logic                                  port_a_cim,
-  input  logic                [  SeedWidth-1:0] cim_seed_hv,
-  input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv,
+  input  logic                                  port_a_cim_i,
+  input  logic                [  SeedWidth-1:0] cim_seed_hv_i,
+  input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv_i,
   input  logic                [ImAddrWidth-1:0] im_a_addr_i,
   input  logic                [ImAddrWidth-1:0] im_b_addr_i,
   output logic                [HVDimension-1:0] im_a_o,
@@ -63,7 +63,7 @@ module item_memory #(
     .DataWidth  ( CimSelWidth       ),
     .NumSel     ( 2                 )
   ) i_mux_cim_in (
-    .sel_i      ( port_a_cim        ),
+    .sel_i      ( port_a_cim_i      ),
     .signal_i   ( mux_cim_addr_in   ),
     .signal_o   ( mux_cim_addr_out  )
   );
@@ -75,7 +75,7 @@ module item_memory #(
     .HVDimension ( HVDimension      ),
     .SeedWidth   ( SeedWidth        )
   ) i_cim (
-    .seed_hv_i   ( cim_seed_hv      ),
+    .seed_hv_i   ( cim_seed_hv_i    ),
     .cim_sel_i   ( mux_cim_addr_out ),
     .cim_o       ( cim_a            )
   );
@@ -92,7 +92,7 @@ module item_memory #(
     .DataWidth  ( ImSelWidth      ),
     .NumSel     ( 2               )
   ) i_mux_im_in (
-    .sel_i      ( port_a_cim      ),
+    .sel_i      ( port_a_cim_i    ),
     .signal_i   ( mux_im_addr_in  ),
     .signal_o   ( mux_im_addr_out )
   );
@@ -106,7 +106,7 @@ module item_memory #(
     .NumPerImBank ( NumPerImBank    ),
     .SeedWidth    ( SeedWidth       )
   ) i_ca90_item_memory (
-    .seed_hv_i    ( im_seed_hv      ),
+    .seed_hv_i    ( im_seed_hv_i    ),
     .im_sel_a_i   ( mux_im_addr_out ),
     .im_sel_b_i   ( im_b_addr_i     ),
     .im_a_o       ( im_a            ),
@@ -125,7 +125,7 @@ module item_memory #(
     .DataWidth  ( HVDimension      ),
     .NumSel     ( 2                )
   ) i_mux_porta_out (
-    .sel_i      ( port_a_cim       ),
+    .sel_i      ( port_a_cim_i     ),
     .signal_i   ( mux_porta_out_in ),
     .signal_o   ( im_a_o           )
   );

--- a/tests/test_item_memory.py
+++ b/tests/test_item_memory.py
@@ -19,12 +19,8 @@ from util import get_root, setup_and_run, check_result_array, numbin2list, hvlis
 hdc_util_path = get_root() + "/hdc_exp/"
 sys.path.append(hdc_util_path)
 
-# Grab the CA90 generation from the
-# cellular automata experiment set
-from cellular_automata import gen_ca90_im_set  # noqa: E402
-
-# Grab the CiM generation from the utility
-from hdc_util import gen_square_cim  # noqa: E402
+# Import item memory generations
+from hdc_util import gen_square_cim, gen_ca90_im_set  # noqa: E402
 
 
 @cocotb.test()
@@ -66,11 +62,11 @@ async def item_memory_dut(dut):
         ) + im_seed_input_list[num_im_banks - i - 1]
 
     # Input the CiM seed and the iM seeds
-    dut.cim_seed_hv.value = cim_seed_input
-    dut.im_seed_hv.value = im_seed_input
+    dut.cim_seed_hv_i.value = cim_seed_input
+    dut.im_seed_hv_i.value = im_seed_input
 
     # Initialize all other ports to 0
-    dut.port_a_cim.value = 0
+    dut.port_a_cim_i.value = 0
     dut.im_a_addr_i.value = 0
     dut.im_b_addr_i.value = 0
 
@@ -81,7 +77,7 @@ async def item_memory_dut(dut):
     cocotb.log.info("         Checking CA90 Item Memory          ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Since port_a_cim is 0, it selects the
+    # Since port_a_cim_i is 0, it selects the
     # CA90 item memory
 
     # Load request, propagate, check result
@@ -104,8 +100,8 @@ async def item_memory_dut(dut):
         check_result_array(actual_val_b, golden_im[i])
 
     # Clear other inputs but put
-    # port_a_cim to 1 to select the CiM
-    dut.port_a_cim.value = 1
+    # port_a_cim_i to 1 to select the CiM
+    dut.port_a_cim_i.value = 1
     dut.im_a_addr_i.value = 0
     dut.im_b_addr_i.value = 0
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -158,7 +158,12 @@ def hv_alu_out(hv_a, hv_b, shift_amt, hv_dim, op):
     elif op == 2:
         result = hv_a | hv_b
     elif op == 3:
-        result = (hv_a >> shift_amt) | (hv_a << (hv_dim - shift_amt)) & mask_val
+        # Workaround because github CI fails
+        # At shifting more than 64 bits
+        if isinstance(hv_a, np.ndarray):
+            result = np.roll(hv_a, shift_amt)
+        else:
+            result = (hv_a >> shift_amt) | (hv_a << (hv_dim - shift_amt)) & mask_val
     else:
         result = hv_a ^ hv_b
     return result

--- a/tests/util.py
+++ b/tests/util.py
@@ -150,17 +150,17 @@ def gen_randint(max_val):
 
 
 # For the ALU output
-def hv_alu_out(A, B, shift_amt, hv_dim, op):
+def hv_alu_out(hv_a, hv_b, shift_amt, hv_dim, op):
     mask_val = 2**hv_dim - 1
 
     if op == 1:
-        result = A & B
+        result = hv_a & hv_b
     elif op == 2:
-        result = A | B
+        result = hv_a | hv_b
     elif op == 3:
-        result = (A >> shift_amt) | (A << (hv_dim - shift_amt)) & mask_val
+        result = (hv_a >> shift_amt) | (hv_a << (hv_dim - shift_amt)) & mask_val
     else:
-        result = A ^ B
+        result = hv_a ^ hv_b
     return result
 
 
@@ -203,8 +203,8 @@ def hvlist2num(hv_list):
 # Clear encoder signal inputs to 0
 def clear_encode_inputs_no_clock(dut):
     # Item memory inputs
-    dut.im_rd_a_i.value = 0
-    dut.im_rd_b_i.value = 0
+    dut.im_a_addr_i.value = 0
+    dut.im_b_addr_i.value = 0
 
     # Control ports for ALU
     dut.alu_mux_a_i.value = 0
@@ -235,13 +235,13 @@ def clear_encode_inputs_no_clock(dut):
     return
 
 
-# Loading from Im to register
-async def load_im_to_reg(dut, hv_data, reg_addr):
+# Loading from IM to register
+async def load_im_to_reg(dut, im_addr, reg_addr):
     # Make sure to clear first
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_rd_a_i.value = hv_data
+    dut.im_a_addr_i.value = im_addr
 
     # Control ports for registers
     dut.reg_mux_i.value = 1
@@ -305,13 +305,13 @@ async def perm_reg_to_qhv(dut, reg_addr, shift_amt):
 
 
 # Bind 2 IM inputs and save to reg
-async def bind_2im_to_reg(dut, hv_a, hv_b, reg_addr):
+async def bind_2im_to_reg(dut, im_addr_a, im_addr_b, reg_addr):
     # Make sure to clear
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_rd_a_i.value = hv_a
-    dut.im_rd_b_i.value = hv_b
+    dut.im_a_addr_i.value = im_addr_a
+    dut.im_b_addr_i.value = im_addr_b
 
     # Control ports for ALU
     dut.alu_mux_a_i.value = 0
@@ -359,12 +359,12 @@ async def bind_2reg_to_reg(dut, reg_addr_a, reg_addr_b, reg_wr_addr):
 
 
 # Load bundler from IM
-async def im_to_bundler(dut, hv_data, bundler_addr):
+async def im_to_bundler(dut, im_a_addr, bundler_addr):
     # Make sure to clear first
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_rd_a_i.value = hv_data
+    dut.im_a_addr_i.value = im_a_addr
 
     # Control ports for bundlers
     if bundler_addr == 0:


### PR DESCRIPTION
This PR instantiates and combines the item memory into the HV encoder. The tests were also updated to use this setup.

Major TODOs:
- [x] Combine the item memory into `hv_encoder`
- [x] Update test to cover changes

Minor TODO:
- [x] Refactor signal names in item memory