### PR TITLE
Add instruction controller

### DIFF
--- a/rtl/common/reg_file_1w1r.sv
+++ b/rtl/common/reg_file_1w1r.sv
@@ -40,14 +40,26 @@ module reg_file_1w1r #(
   always_ff @ (posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Initialize to 0 during resets
-      for (int i = 0; i < NumRegs; i++) begin
-        reg_file[i] <= {DataWidth{1'b0}};
-      end
-    end else begin
-      if(clr_i) begin
+`ifdef SIM_VLT
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] = {DataWidth{1'b0}}; // verilog_lint: waive always-ff-non-blocking
+        end
+`else
         for (int i = 0; i < NumRegs; i++) begin
           reg_file[i] <= {DataWidth{1'b0}};
         end
+`endif
+    end else begin
+      if(clr_i) begin
+`ifdef SIM_VLT
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] = {DataWidth{1'b0}}; // verilog_lint: waive always-ff-non-blocking
+        end
+`else
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] <= {DataWidth{1'b0}};
+        end
+`endif
       end else if(wr_en_i) begin
         reg_file[wr_addr_i] <= wr_data_i;
       end else begin

--- a/rtl/common/reg_file_1w2r.sv
+++ b/rtl/common/reg_file_1w2r.sv
@@ -43,14 +43,26 @@ module reg_file_1w2r #(
   always_ff @ (posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Initialize to 0 during resets
-      for (int i = 0; i < NumRegs; i++) begin
-        reg_file[i] <= {DataWidth{1'b0}};
-      end
-    end else begin
-      if(clr_i) begin
+`ifdef SIM_VLT
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] = {DataWidth{1'b0}}; // verilog_lint: waive always-ff-non-blocking
+        end
+`else
         for (int i = 0; i < NumRegs; i++) begin
           reg_file[i] <= {DataWidth{1'b0}};
         end
+`endif
+    end else begin
+      if(clr_i) begin
+`ifdef SIM_VLT
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] = {DataWidth{1'b0}}; // verilog_lint: waive always-ff-non-blocking
+        end
+`else
+        for (int i = 0; i < NumRegs; i++) begin
+          reg_file[i] <= {DataWidth{1'b0}};
+        end
+`endif
       end else if(wr_en_i) begin
         reg_file[wr_addr_i] <= wr_data_i;
       end else begin

--- a/rtl/inst_memory/inst_control.sv
+++ b/rtl/inst_memory/inst_control.sv
@@ -1,0 +1,88 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Instruction Control
+// Description:
+// This module handles the management or
+// control of the instruction memory
+//---------------------------
+
+module inst_control # (
+  parameter int unsigned RegAddrWidth     = 32,
+  parameter int unsigned InstMemDepth     = 128,
+  // Don't touch!
+  parameter int unsigned InstMemAddrWidth = $clog2(InstMemDepth)
+)(
+  // Clocks and reset
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+  // Control signals
+  input  logic                    clr_i,
+  input  logic                    en_i,
+  input  logic                    stall_i,
+  input  logic [RegAddrWidth-1:0] inst_wr_addr_i,
+  input  logic [RegAddrWidth-1:0] inst_wr_data_i,
+  input  logic                    inst_wr_en_i,
+  output logic [RegAddrWidth-1:0] inst_pc_o,
+  output logic [RegAddrWidth-1:0] inst_rd_o,
+  // Debug control signals
+  input  logic                    dbg_en_i,
+  input  logic [RegAddrWidth-1:0] dbg_addr_i
+);
+
+  //---------------------------
+  // Wires and Logic
+  //---------------------------
+  logic [InstMemAddrWidth-1:0] program_counter;
+  logic [InstMemAddrWidth-1:0] inst_rd_addr;
+
+  //---------------------------
+  // Direct Assignments
+  //---------------------------
+  assign inst_pc_o    = program_counter;
+  assign inst_rd_addr = (dbg_en_i) ? dbg_addr_i[InstMemAddrWidth-1:0] : program_counter;
+
+  //---------------------------
+  // Program counter
+  // Stall when stall is asserted
+  // or when debug is asserted
+  //---------------------------
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      program_counter <= {InstMemAddrWidth{1'b0}};
+    end else begin
+      if(clr_i) begin
+        program_counter <= {InstMemAddrWidth{1'b0}};
+      end else if (en_i && !stall_i && !dbg_en_i) begin
+        program_counter <= program_counter + 1;
+      end else begin
+        program_counter <= program_counter;
+      end
+    end
+  end
+
+  //---------------------------
+  // Instruction memory
+  // Use register for this but can
+  // be replaced with an actual memory
+  //---------------------------
+
+  reg_file_1w1r #(
+    .DataWidth  ( RegAddrWidth                         ),
+    .NumRegs    ( InstMemDepth                         )
+  ) i_inst_mem (
+    // Clocks and resets
+    .clk_i      ( clk_i                                ),
+    .rst_ni     ( rst_ni                               ),
+    // Write port
+    .clr_i      ( clr_i                                ),
+    .wr_addr_i  ( inst_wr_addr_i[InstMemAddrWidth-1:0] ),
+    .wr_data_i  ( inst_wr_data_i                       ),
+    .wr_en_i    ( inst_wr_en_i                         ),
+    // Read port A
+    .rd_addr_i  ( inst_rd_addr                         ),
+    .rd_data_o  ( inst_rd_o                            )
+  );
+
+endmodule

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -20,6 +20,9 @@ NUM_TOT_IM = 256
 NUM_PER_IM_BANK = int(HV_DIM // 4)
 CA90_MODE = "ca90_hier"
 
+# Instruction memory parameters
+INST_MEM_DEPTH = 128
+
 # Encoder parameters
 BUNDLER_COUNT_WIDTH = 8
 BUNDLER_MUX_WIDTH = 2
@@ -32,4 +35,4 @@ REG_NUM = 4
 # Shift amount needs to be in odd number form
 # because the shifts is from 0 to some dimension
 # here, we restrict shift amount to be half of the total dimension
-MAX_SHIFT_AMT = int(HV_DIM / 2) - 1
+MAX_SHIFT_AMT = 4

--- a/tests/test_ca90_unit.py
+++ b/tests/test_ca90_unit.py
@@ -43,7 +43,7 @@ async def ca90_unit_dut(dut):
         # Generate random input but convert
         seed_hv = gen_rand_bits(set_parameters.HV_DIM)
         # Random CA90 cycle time
-        ca90_cycle_time = gen_randint(set_parameters.MAX_SHIFT_AMT)
+        ca90_cycle_time = gen_randint(set_parameters.MAX_SHIFT_AMT - 1)
 
         # Load data into inputs
         dut.vector_i.value = seed_hv

--- a/tests/test_hv_alu_pe.py
+++ b/tests/test_hv_alu_pe.py
@@ -16,12 +16,12 @@ import pytest
 
 
 # Routinary test
-async def gen_and_test(dut, hv_dim, max_shift_amt, mode):
+async def gen_and_test(dut, hv_dim, shift_amt, mode):
     # Generate data
     if mode == 3:
         A = gen_rand_bits(set_parameters.HV_DIM)
         B = 0
-        shift_amt = gen_randint(max_shift_amt)
+        shift_amt = gen_randint(shift_amt)
     else:
         A = gen_rand_bits(set_parameters.HV_DIM)
         B = gen_rand_bits(set_parameters.HV_DIM)
@@ -65,7 +65,7 @@ async def hv_alu_pe_dut(dut):
 
     # Test the XOR case
     for i in range(set_parameters.TEST_RUNS):
-        await gen_and_test(dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT, 0)
+        await gen_and_test(dut, set_parameters.HV_DIM, 0, 0)
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("             Testing AND Cases              ")
@@ -73,7 +73,7 @@ async def hv_alu_pe_dut(dut):
 
     # Test the AND case
     for i in range(set_parameters.TEST_RUNS):
-        await gen_and_test(dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT, 1)
+        await gen_and_test(dut, set_parameters.HV_DIM, 0, 1)
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("             Testing OR Cases               ")
@@ -81,7 +81,7 @@ async def hv_alu_pe_dut(dut):
 
     # Test the OR case
     for i in range(set_parameters.TEST_RUNS):
-        await gen_and_test(dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT, 2)
+        await gen_and_test(dut, set_parameters.HV_DIM, 0, 2)
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("       Testing Circular Shift Cases         ")
@@ -89,7 +89,9 @@ async def hv_alu_pe_dut(dut):
 
     # Test circular shift cases
     for i in range(set_parameters.TEST_RUNS):
-        await gen_and_test(dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT, 3)
+        await gen_and_test(
+            dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT - 1, 3
+        )
 
 
 # Actual test run

--- a/tests/test_inst_control.py
+++ b/tests/test_inst_control.py
@@ -1,0 +1,171 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the basic functionality
+  of the instruction control
+"""
+
+import set_parameters
+import cocotb
+from cocotb.clock import Clock
+import pytest
+
+from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
+
+
+def clear_inputs_no_clock(dut):
+    dut.clr_i.value = 0
+    dut.en_i.value = 0
+    dut.stall_i.value = 0
+    dut.inst_wr_addr_i.value = 0
+    dut.inst_wr_data_i.value = 0
+    dut.inst_wr_en_i.value = 0
+    dut.dbg_en_i.value = 0
+    dut.dbg_addr_i.value = 0
+    return
+
+
+async def write_inst_mem(dut, inst_addr, inst_data):
+    clear_inputs_no_clock(dut)
+    dut.inst_wr_addr_i.value = inst_addr
+    dut.inst_wr_data_i.value = inst_data
+    dut.inst_wr_en_i.value = 1
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return
+
+
+async def read_dbg(dut, addr):
+    clear_inputs_no_clock(dut)
+    dut.dbg_en_i.value = 1
+    dut.dbg_addr_i.value = addr
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return
+
+
+@cocotb.test()
+async def inst_control_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("        Testing Instruction Control         ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize input values
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+
+    dut.rst_ni.value = 1
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("       Writing to Instruction Memory        ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Generate golden data to write
+    golden_data_list = []
+    for i in range(set_parameters.INST_MEM_DEPTH):
+        golden_data_list.append(gen_rand_bits(set_parameters.REG_FILE_WIDTH))
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("     Check values with program counter      ")
+    cocotb.log.info(" ------------------------------------------ ")
+    # Write the data to instruction memory
+    for i in range(set_parameters.INST_MEM_DEPTH):
+        await write_inst_mem(dut, i, golden_data_list[i])
+
+    # Check result immediatley through program counter
+    # first activate or enable the program counter
+    # then for every clock cycle check the output data
+    dut.en_i.value = 1
+
+    for i in range(set_parameters.INST_MEM_DEPTH):
+        # Extract the 1st data that is readily available
+        pc_val = dut.inst_pc_o.value.integer
+        inst_data_val = dut.inst_rd_o.value.integer
+
+        check_result(pc_val, i)
+        check_result(inst_data_val, golden_data_list[i])
+
+        await clock_and_time(dut.clk_i)
+
+    # Redo the test but this time use the debug port
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("        Check values with debug mode        ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Clear first
+    clear_inputs_no_clock(dut)
+    await clock_and_time(dut.clk_i)
+
+    # Load the address then check immediateley
+    for i in range(set_parameters.INST_MEM_DEPTH):
+        await read_dbg(dut, i)
+        inst_data_val = dut.inst_rd_o.value.integer
+        check_result(inst_data_val, golden_data_list[i])
+
+    # This is for waveform checking later
+    for i in range(set_parameters.TEST_RUNS):
+        # Propagate time for logic
+        await clock_and_time(dut.clk_i)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("             Test clear signal              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Clear first
+    clear_inputs_no_clock(dut)
+    await clock_and_time(dut.clk_i)
+
+    dut.clr_i.value = 1
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+
+    # Enable again
+    dut.en_i.value = 1
+
+    # Check only the output and results need to be 0
+    for i in range(set_parameters.INST_MEM_DEPTH):
+        # Extract the 1st data that is readily available
+        inst_data_val = dut.inst_rd_o.value.integer
+
+        check_result(inst_data_val, 0)
+
+        await clock_and_time(dut.clk_i)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "RegAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            "InstMemDepth": str(set_parameters.INST_MEM_DEPTH),
+        }
+    ],
+)
+def test_inst_control(simulator, parameters, waves):
+    verilog_sources = [
+        "/rtl/common/reg_file_1w1r.sv",
+        "/rtl/inst_memory/inst_control.sv",
+    ]
+
+    toplevel = "inst_control"
+
+    module = "test_inst_control"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/util.py
+++ b/tests/util.py
@@ -56,8 +56,13 @@ def setup_and_run(
     # Setting of compilation arguments
     # and timescale depending on simulator
     if simulator == "verilator":
-        compile_args = ["-Wno-WIDTH", "--no-timing", "--trace-structs"]
+        compile_args = [
+            "-Wno-WIDTH",
+            "--no-timing",
+            "--trace-structs",
+        ]
         timescale = None
+        defines = ["SIM_VLT"]
     else:
         compile_args = None
         timescale = "1ns/1ps"


### PR DESCRIPTION
This PR adds the instruction memory controller. It also contains the instruction memory in the form of a register. This is replaceable for future purposes.

Major TODO:
- [x] Make instruction control
- [x] Make instruction control test

Minor TODO:
- [x] Add switcher for verilator. **Note: Verilator does not support blocking assignments and for loops for synchronous updates. It's a limitation of the Verilator but it works in questa sim. Therefore a switcher is added. Refer to: [BLOCKLOOPLINT](https://verilator.org/guide/latest/warnings.html#cmdoption-arg-BLKLOOPINIT)**