### PR TITLE
Revert "Combine item memory into HV encoder (#30)"

### DIFF
--- a/tests/test_hv_encoder.py
+++ b/tests/test_hv_encoder.py
@@ -6,11 +6,11 @@
   This tests the vectorized bundler unit
 """
 
-from hdc_exp.hdc_util import numbin2list
 import set_parameters
 from util import (
     get_root,
     setup_and_run,
+    gen_rand_bits,
     clock_and_time,
     clear_encode_inputs_no_clock,
     load_reg_to_qhv,
@@ -22,8 +22,9 @@ from util import (
     load_bundler_to_reg,
     load_bundler_to_qhv,
     hv_alu_out,
+    numbip2list,
     hvlist2num,
-    check_result_array,
+    check_result,
 )
 
 import cocotb
@@ -38,11 +39,10 @@ hdc_util_path = get_root() + "/hdc_exp/"
 print(hdc_util_path)
 sys.path.append(hdc_util_path)
 
-# Import item memory generations
-from hdc_util import gen_square_cim, gen_ca90_im_set, binarize_hv  # noqa: E402
+from hdc_util import binarize_hv  # noqa: E402
 
-# Local parameters
-BUNDLE_COUNT = 10
+# Some local parameters
+IM_LEN = 10
 
 
 # Actual test routines
@@ -65,43 +65,14 @@ async def hv_encoder_dut(dut):
 
     dut.rst_ni.value = 1
 
-    cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("     Generate Seeds and Golden Values       ")
-    cocotb.log.info(" ------------------------------------------ ")
+    # Randomly generate a set of IM data
+    # Just set 10 for now
+    im_a_list = []
+    im_b_list = []
 
-    # Generated golden CiM
-    cim_seed_input, golden_cim = gen_square_cim(
-        hv_dim=set_parameters.HV_DIM,
-        seed_size=set_parameters.REG_FILE_WIDTH,
-        im_type=set_parameters.CA90_MODE,
-    )
-
-    # Convert seed list to number
-    cim_seed_input = hvlist2num(cim_seed_input)
-
-    # Generate seed list and golden IM
-    im_seed_input_list, golden_im, conf_mat = gen_ca90_im_set(
-        seed_size=set_parameters.REG_FILE_WIDTH,
-        hv_dim=set_parameters.HV_DIM,
-        num_total_im=set_parameters.NUM_TOT_IM,
-        num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
-        ca90_mode=set_parameters.CA90_MODE,
-    )
-
-    # For combining into a single
-    # wire bus for simulation purposes
-    num_im_banks = int(set_parameters.NUM_TOT_IM / set_parameters.NUM_PER_IM_BANK)
-    im_seed_input = 0
-    for i in range(num_im_banks):
-        im_seed_input = (
-            im_seed_input << set_parameters.REG_FILE_WIDTH
-        ) + im_seed_input_list[num_im_banks - i - 1]
-
-    # Input the CiM seed and the iM seeds
-    dut.cim_seed_hv_i.value = cim_seed_input
-    dut.im_seed_hv_i.value = im_seed_input
-
-    # Initially let's use the CA90 first
+    for i in range(IM_LEN):
+        im_a_list.append(gen_rand_bits(set_parameters.HV_DIM))
+        im_b_list.append(gen_rand_bits(set_parameters.HV_DIM))
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("              IM > Regs > QHV               ")
@@ -109,7 +80,7 @@ async def hv_encoder_dut(dut):
 
     # Loading item memory HVs to registers
     for i in range(set_parameters.REG_NUM):
-        await load_im_to_reg(dut, i, i)
+        await load_im_to_reg(dut, im_a_list[i], i)
 
     # Move from regs to QHV
     for i in range(set_parameters.REG_NUM):
@@ -117,11 +88,11 @@ async def hv_encoder_dut(dut):
         await load_reg_to_qhv(dut, i)
 
         # Extract answers
-        qhv_val = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
-        golden_val = golden_im[i]
+        qhv_val = dut.qhv_o.value.integer
+        golden_val = im_a_list[i]
 
         # Check if QHV is correct
-        check_result_array(qhv_val, golden_val)
+        check_result(qhv_val, golden_val)
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("            Regs > Shift > QHV              ")
@@ -132,50 +103,36 @@ async def hv_encoder_dut(dut):
         random_shift = random.randrange(int(set_parameters.MAX_SHIFT_AMT))
 
         # Get golden answer first
-        golden_val = hv_alu_out(
-            hv_a=golden_im[i],
-            hv_b=0,
-            shift_amt=random_shift,
-            hv_dim=set_parameters.HV_DIM,
-            op=3,
-        )
+        golden_val = hv_alu_out(im_a_list[i], 0, random_shift, set_parameters.HV_DIM, 3)
 
         # Plug in control signals into encoder
         await perm_reg_to_qhv(dut, i, random_shift)
 
         # Extract answer
-        qhv_val = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+        qhv_val = dut.qhv_o.value.integer
 
         # Check if QHV is correct
-        check_result_array(qhv_val, golden_val)
+        check_result(qhv_val, golden_val)
 
     cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("     IM A and B > ALU bind > Regs > QHV     ")
+    cocotb.log.info("       IM A and B > ALU > Regs > QHV        ")
     cocotb.log.info(" ------------------------------------------ ")
 
     for i in range(set_parameters.REG_NUM):
         # Get golden answer first
-        golden_val = hv_alu_out(
-            hv_a=golden_im[i],
-            hv_b=golden_im[set_parameters.REG_NUM + i],
-            shift_amt=0,
-            hv_dim=set_parameters.HV_DIM,
-            op=0,
-        )
+        golden_val = hv_alu_out(im_a_list[i], im_b_list[i], 0, set_parameters.HV_DIM, 0)
 
         # Bind from 2 im and save to register
-        await bind_2im_to_reg(
-            dut=dut, im_addr_a=i, im_addr_b=set_parameters.REG_NUM + i, reg_addr=i
-        )
+        await bind_2im_to_reg(dut, im_a_list[i], im_b_list[i], i)
 
         # Move register to qhv
         await load_reg_to_qhv(dut, i)
 
         # Extract answer
-        qhv_val = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+        qhv_val = dut.qhv_o.value.integer
 
         # Check if QHV is correct
-        check_result_array(qhv_val, golden_val)
+        check_result(qhv_val, golden_val)
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("      Reg A and B > ALU > Regs > QHV        ")
@@ -184,7 +141,7 @@ async def hv_encoder_dut(dut):
     # For this part we will do a specific routine
     # 1. Load data from IM to register
     for i in range(set_parameters.REG_NUM):
-        await load_im_to_reg(dut, i, i)
+        await load_im_to_reg(dut, im_a_list[i], i)
 
     # 2. Grab HA A and HV B from register
     # and store back to 1st and 2nd respectively
@@ -192,19 +149,19 @@ async def hv_encoder_dut(dut):
     await bind_2reg_to_reg(dut, 2, 3, 1)
 
     # Get golden answers from here
-    test_hv_0 = golden_im[0] ^ golden_im[1]
-    test_hv_1 = golden_im[2] ^ golden_im[3]
+    test_hv_0 = im_a_list[0] ^ im_a_list[1]
+    test_hv_1 = im_a_list[2] ^ im_a_list[3]
 
     # 3. Load to the QHV output and check results
     await load_reg_to_qhv(dut, 0)
-    qhv_val = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+    qhv_val = dut.qhv_o.value.integer
 
-    check_result_array(test_hv_0, qhv_val)
+    check_result(test_hv_0, qhv_val)
 
     await load_reg_to_qhv(dut, 1)
-    qhv_val = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+    qhv_val = dut.qhv_o.value.integer
 
-    check_result_array(test_hv_1, qhv_val)
+    check_result(test_hv_1, qhv_val)
 
     cocotb.log.info(" ------------------------------------------------ ")
     cocotb.log.info("   IM > Bundler > Reg > QHV > or Bundler > QHV    ")
@@ -213,37 +170,37 @@ async def hv_encoder_dut(dut):
     for bundler_addr in range(2):
         # Do this for the item length count
         golden_hv_bundle = np.zeros(set_parameters.HV_DIM)
-        for i in range(BUNDLE_COUNT):
+        for i in range(IM_LEN):
             # Bindle from IM to bundler
-            await im_to_bundler(dut, i, bundler_addr)
+            await im_to_bundler(dut, im_a_list[i], bundler_addr)
 
             # Get ideal bundle score
-            # golden_hv_bundle += numbip2list(golden_im[i], set_parameters.HV_DIM)
-            golden_hv_bundle += golden_im[i]
+            golden_hv_bundle += numbip2list(im_a_list[i], set_parameters.HV_DIM)
 
         # Binarize golden value
         # Combine into bit-wise info
-        golden_hv_bundle = binarize_hv(golden_hv_bundle, int(BUNDLE_COUNT / 2))
+        golden_hv_bundle = binarize_hv(golden_hv_bundle, 0)
+        golden_hv_bundle = hvlist2num(golden_hv_bundle)
 
         # Load from binarized bundler to register 0
         # Then from register 0 to QHV
         await load_bundler_to_reg(dut, bundler_addr, 0)
         await load_reg_to_qhv(dut, 0)
 
-        # Extract the QHV output
-        actual_hv_bundle = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+        # Extract the qhv output
+        actual_hv_bundle = dut.qhv_o.value.integer
 
         # Compare results
-        check_result_array(actual_hv_bundle, golden_hv_bundle)
+        check_result(actual_hv_bundle, golden_hv_bundle)
 
         # Move the bundler to QHV
         await load_bundler_to_qhv(dut, bundler_addr)
 
         # Extract the qhv output
-        actual_hv_bundle = numbin2list(dut.qhv_o.value.integer, set_parameters.HV_DIM)
+        actual_hv_bundle = dut.qhv_o.value.integer
 
         # Compare results
-        check_result_array(actual_hv_bundle, golden_hv_bundle)
+        check_result(actual_hv_bundle, golden_hv_bundle)
 
     # Some trailing cycles only
     for i in range(10):
@@ -256,10 +213,6 @@ async def hv_encoder_dut(dut):
     [
         {
             "HVDimension": str(set_parameters.HV_DIM),
-            "NumTotIm": str(set_parameters.NUM_TOT_IM),
-            "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
-            "ImAddrWidth": str(set_parameters.REG_FILE_WIDTH),
-            "SeedWidth": str(set_parameters.REG_FILE_WIDTH),
             "BundCountWidth": str(set_parameters.BUNDLER_COUNT_WIDTH),
             "BundMuxWidth": str(set_parameters.BUNDLER_MUX_WIDTH),
             "ALUMuxWidth": str(set_parameters.ALU_MUX_WIDTH),
@@ -272,20 +225,10 @@ async def hv_encoder_dut(dut):
 )
 def test_hv_encoder(simulator, parameters, waves):
     verilog_sources = [
-        # Level 0
-        "/rtl/common/mux.sv",
         "/rtl/common/reg_file_1w2r.sv",
-        "/rtl/item_memory/ca90_unit.sv",
-        "/rtl/item_memory/cim_bit_flip.sv",
         "/rtl/hv_alu_pe.sv",
         "/rtl/bundler_unit.sv",
-        # Level 1
-        "/rtl/item_memory/ca90_hier_base.sv",
-        "/rtl/item_memory/cim.sv",
-        "/rtl/item_memory/ca90_item_memory.sv",
         "/rtl/bundler_set.sv",
-        # Level 2
-        "/rtl/item_memory/item_memory.sv",
         "/rtl/hv_encoder.sv",
     ]
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -213,8 +213,8 @@ def hvlist2num(hv_list):
 # Clear encoder signal inputs to 0
 def clear_encode_inputs_no_clock(dut):
     # Item memory inputs
-    dut.im_a_addr_i.value = 0
-    dut.im_b_addr_i.value = 0
+    dut.im_rd_a_i.value = 0
+    dut.im_rd_b_i.value = 0
 
     # Control ports for ALU
     dut.alu_mux_a_i.value = 0
@@ -245,13 +245,13 @@ def clear_encode_inputs_no_clock(dut):
     return
 
 
-# Loading from IM to register
-async def load_im_to_reg(dut, im_addr, reg_addr):
+# Loading from Im to register
+async def load_im_to_reg(dut, hv_data, reg_addr):
     # Make sure to clear first
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_a_addr_i.value = im_addr
+    dut.im_rd_a_i.value = hv_data
 
     # Control ports for registers
     dut.reg_mux_i.value = 1
@@ -315,13 +315,13 @@ async def perm_reg_to_qhv(dut, reg_addr, shift_amt):
 
 
 # Bind 2 IM inputs and save to reg
-async def bind_2im_to_reg(dut, im_addr_a, im_addr_b, reg_addr):
+async def bind_2im_to_reg(dut, hv_a, hv_b, reg_addr):
     # Make sure to clear
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_a_addr_i.value = im_addr_a
-    dut.im_b_addr_i.value = im_addr_b
+    dut.im_rd_a_i.value = hv_a
+    dut.im_rd_b_i.value = hv_b
 
     # Control ports for ALU
     dut.alu_mux_a_i.value = 0
@@ -369,12 +369,12 @@ async def bind_2reg_to_reg(dut, reg_addr_a, reg_addr_b, reg_wr_addr):
 
 
 # Load bundler from IM
-async def im_to_bundler(dut, im_a_addr, bundler_addr):
+async def im_to_bundler(dut, hv_data, bundler_addr):
     # Make sure to clear first
     clear_encode_inputs_no_clock(dut)
 
     # Item memory inputs
-    dut.im_a_addr_i.value = im_a_addr
+    dut.im_rd_a_i.value = hv_data
 
     # Control ports for bundlers
     if bundler_addr == 0:


### PR DESCRIPTION
This PR reverts a specific set of commits because its goal is to bring back the old changes before the combining of the encoder.

The reason for this is to separate the item memory from the encoder and be part of a **fetch and project** unit. See a visualization below:

![image](https://github.com/user-attachments/assets/a4a198ac-4783-44db-82de-f5c6f2acaa10)
