### PR TITLE
Modify ALU to have pass throughs

### DIFF
--- a/rtl/hv_alu_pe.sv
+++ b/rtl/hv_alu_pe.sv
@@ -37,14 +37,14 @@ module hv_alu_pe #(
   // Logic table:
   // op_i | operation         |
   // 0    | XOR               |
-  // 1    | AND               |
-  // 2    | OR                |
+  // 1    | A_i pass through  |
+  // 2    | B_i pass through  |
   // 3    | Circular shifts   |
   //---------------------------
   always_comb begin : alu_logic
     case (op_i)
-      2'b01:   C_o = A_i & B_i;
-      2'b10:   C_o = A_i | B_i;
+      2'b01:   C_o = A_i;
+      2'b10:   C_o = B_i;
       2'b11:   C_o = circular_shift_res;
       default: C_o = A_i ^ B_i;
     endcase

--- a/tests/test_hv_alu_pe.py
+++ b/tests/test_hv_alu_pe.py
@@ -104,7 +104,7 @@ async def hv_alu_pe_dut(dut):
         }
     ],
 )
-def test_hv_alu_pe(simulator, parameters):
+def test_hv_alu_pe(simulator, parameters, waves):
     verilog_sources = ["/rtl/hv_alu_pe.sv"]
 
     toplevel = "hv_alu_pe"
@@ -117,4 +117,5 @@ def test_hv_alu_pe(simulator, parameters):
         module=module,
         simulator=simulator,
         parameters=parameters,
+        waves=waves,
     )

--- a/tests/util.py
+++ b/tests/util.py
@@ -159,9 +159,9 @@ def hv_alu_out(hv_a, hv_b, shift_amt, hv_dim, op):
     mask_val = 2**hv_dim - 1
 
     if op == 1:
-        result = hv_a & hv_b
+        result = hv_a
     elif op == 2:
-        result = hv_a | hv_b
+        result = hv_b
     elif op == 3:
         # Workaround because github CI fails
         # At shifting more than 64 bits


### PR DESCRIPTION
This PR replaces the AND and OR ALU operations with pass-throughs instead. The motivation is that bit-wise AND and OR are not used for dense representations.

Major TODO:
- [x] Modify ALU
- [x] Modify corresponding test

Minor TODO:
- [x] Add waves parameter