### PR TITLE
Add FIFO common module

### DIFF
--- a/rtl/common/fifo.sv
+++ b/rtl/common/fifo.sv
@@ -1,0 +1,189 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: FIFO Module
+// Description:
+// Basic common FIFO utility module
+// This is a derivative of the original FIFO
+// made from the PULP common cells
+//---------------------------
+
+module fifo #(
+  parameter bit          FallThrough   = 1'b0,
+  parameter int unsigned DataWidth     = 32,
+  parameter int unsigned FifoDepth     = 8,
+  // Touch this only if you plan
+  // to change the data type to be used
+  parameter type dtype                 = logic [DataWidth-1:0],
+  // Don't touch!
+  parameter int unsigned FifoAddrWidth = (FifoDepth > 1) ? $clog2(FifoDepth) : 1
+)(
+  // Clocks and reset
+  input  logic  clk_i,
+  input  logic  rst_ni,
+  // Software synchronous clear
+  input  logic  clr_i,
+  // Status flags
+  output logic  full_o,
+  output logic  empty_o,
+  // Note that this counter state is index 1
+  output logic  [FifoAddrWidth:0] counter_state_o,
+  // Input push
+  input  dtype  data_i,
+  input  logic  push_i,
+  // Output pop
+  output dtype  data_o,
+  input  logic  pop_i
+);
+
+  //---------------------------
+  // Local parameter
+  //---------------------------
+
+  // Pointers to the read and write sections of the queue
+  logic [FifoAddrWidth-1:0] read_pointer_n, read_pointer_q;
+  logic [FifoAddrWidth-1:0] write_pointer_n, write_pointer_q;
+
+  // keep a counter to keep track of the current queue status
+  // this integer will be truncated by the synthesis tool
+  logic [FifoAddrWidth:0] status_cnt_n, status_cnt_q;
+
+  // Main FIFO component
+  dtype [FifoDepth-1:0] mem_n, mem_q;
+
+  //---------------------------
+  // Some useful logic and
+  // assignments for status flags
+  //---------------------------
+  assign counter_state_o = status_cnt_q[FifoAddrWidth:0];
+
+  if (FifoDepth == 0) begin : gen_pass_through
+      assign empty_o = ~push_i;
+      assign full_o  = ~pop_i;
+  end else begin : gen_fifo
+      assign full_o  = (status_cnt_q == FifoDepth);
+      assign empty_o = (status_cnt_q == 0) & ~(FallThrough & push_i);
+  end
+
+  // Read and write combinational logic
+  always_comb begin : read_write_comb
+
+      // Default assignments
+      read_pointer_n  = read_pointer_q;
+      write_pointer_n = write_pointer_q;
+      status_cnt_n    = status_cnt_q;
+      data_o          = (FifoDepth == 0) ? data_i : mem_q[read_pointer_q];
+      mem_n           = mem_q;
+
+      //---------------------------
+      // Push logic
+      //---------------------------
+
+      // Can push as long as queue is not full
+      // Handling incoming data must come
+      // from the outside and not in here
+      if (push_i && ~full_o) begin
+
+          // Push the data onto the queue
+          mem_n[write_pointer_q] = data_i;
+
+          // Increment the write counter
+          // this is dead code when FifoDepth is a power of two
+          if (write_pointer_q == FifoDepth-1)
+              write_pointer_n = '0;
+          else
+              write_pointer_n = write_pointer_q + 1;
+
+          // Increment the overall counter
+          status_cnt_n= status_cnt_q + 1;
+      end
+
+      //---------------------------
+      // Pop logic
+      //---------------------------
+
+      // Can pop as long as queue is not empty
+      // Handling incoming data must come
+      // from the outside and not in here
+      if (pop_i && ~empty_o) begin
+
+          // Read from the queue is a default assignment
+          // but increment the read pointer when success
+          if (read_pointer_n == FifoDepth-1)
+              read_pointer_n = '0;
+          else
+              read_pointer_n = read_pointer_q + 1;
+
+          // Decerement the overall counter
+          status_cnt_n   = status_cnt_q - 1;
+      end
+
+      // Keep the count pointer for simultaneous push and pop
+      // and as long as it's neither full nor empty
+      if (push_i && pop_i &&  ~full_o && ~empty_o)
+          status_cnt_n   = status_cnt_q;
+
+      // FIFO is in pass through mode -> do not change the pointers
+      if (FallThrough && (status_cnt_q == 0) && push_i) begin
+          data_o = data_i;
+          if (pop_i) begin
+              status_cnt_n = status_cnt_q;
+              read_pointer_n = read_pointer_q;
+              write_pointer_n = write_pointer_q;
+          end
+      end
+  end
+
+  //---------------------------
+  // State updates
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+      if(~rst_ni) begin
+          read_pointer_q  <= '0;
+          write_pointer_q <= '0;
+          status_cnt_q    <= '0;
+      end else begin
+          if (clr_i) begin
+              read_pointer_q  <= '0;
+              write_pointer_q <= '0;
+              status_cnt_q    <= '0;
+            end else begin
+              read_pointer_q  <= read_pointer_n;
+              write_pointer_q <= write_pointer_n;
+              status_cnt_q    <= status_cnt_n;
+          end
+      end
+  end
+
+  //---------------------------
+  // Actual fifo updates
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+      if(~rst_ni) begin
+          mem_q <= '0;
+      end else begin
+          mem_q <= mem_n;
+      end
+  end
+
+  //---------------------------
+  // Sanity checking
+  //---------------------------
+`ifndef SYNTHESIS
+`ifndef COMMON_CELLS_ASSERTS_OFF
+  initial begin
+      assert (FifoDepth > 0) else $error("FifoDepth must be greater than 0.");
+  end
+
+  full_write : assert property(
+      @(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
+      else $fatal (1, "Trying to push new data although the FIFO is full.");
+
+  empty_read : assert property(
+      @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
+      else $fatal (1, "Trying to pop data although the FIFO is empty.");
+`endif
+`endif
+
+endmodule

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -1,0 +1,177 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the basic functionality of the
+  register set with 1 write and 1 read port
+"""
+
+from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
+
+import cocotb
+from cocotb.clock import Clock
+import pytest
+
+# Some local parameters for testing
+FALL_THROUGH = 0
+DATA_WIDTH = 32
+FIFO_DEPTH = 32
+
+
+# Set inputs to 0
+def clear_inputs_no_clock(dut):
+    # Write ports
+    dut.clr_i.value = 0
+    # Push port
+    dut.data_i.value = 0
+    dut.push_i.value = 0
+    # Pop port
+    dut.pop_i.value = 0
+    return
+
+
+# Push to FIFO
+async def push_fifo(dut, data):
+    clear_inputs_no_clock(dut)
+    dut.data_i.value = data
+    dut.push_i.value = 1
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return
+
+
+# Read first then pop
+async def pop_fifo(dut):
+    clear_inputs_no_clock(dut)
+    data = dut.data_o.value.integer
+    dut.pop_i.value = 1
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return data
+
+
+# Clear FIFO
+async def clr_fifo(dut):
+    dut.clr_i.value = 1
+    await clock_and_time(dut.clk_i)
+
+
+# Generate random data first
+def gen_rand_data_list(num_elem, datawidth):
+    rand_data_list = []
+    for i in range(num_elem):
+        rand_data_list.append(gen_rand_bits(datawidth))
+    return rand_data_list
+
+
+@cocotb.test()
+async def fifo_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("             Testing FIFO unit              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize input values
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+
+    dut.rst_ni.value = 1
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("           Pushing data to FIFO             ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    rand_data_list = gen_rand_data_list(FIFO_DEPTH, DATA_WIDTH)
+
+    for i in range(FIFO_DEPTH):
+        # Get current counter and see if it's at the correct state
+        counter_val = dut.counter_state_o.value.integer
+        check_result(counter_val, i)
+        await push_fifo(dut, rand_data_list[i])
+
+    # Since the FIFO is full check if the full state is high
+    # and check if the empty state is low
+    full_state = dut.full_o.value.integer
+    empty_state = dut.empty_o.value.integer
+    check_result(full_state, 1)
+    check_result(empty_state, 0)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Read and POP from FIFO            ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    for i in range(FIFO_DEPTH):
+        # First check if counter decrement is correct
+        counter_val = dut.counter_state_o.value.integer
+        check_result(counter_val, FIFO_DEPTH - i)
+
+        # Then pop the value
+        pop_fifo_val = await pop_fifo(dut)
+        check_result(pop_fifo_val, rand_data_list[i])
+
+    # Since the FIFO is empty check if the full state is low
+    # and check if the empty state is high
+    full_state = dut.full_o.value.integer
+    empty_state = dut.empty_o.value.integer
+    check_result(full_state, 0)
+    check_result(empty_state, 1)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("            Fill and clear FIFO             ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    clear_inputs_no_clock(dut)
+
+    # Fill FIFO again can do rechecking for sanity purposes
+    for i in range(FIFO_DEPTH):
+        # Get current counter and see if it's at the correct state
+        counter_val = dut.counter_state_o.value.integer
+        check_result(counter_val, i)
+        await push_fifo(dut, rand_data_list[i])
+
+    # Clear FIFO
+    await clr_fifo(dut)
+
+    # A clear makes sure the FIFO is immediately empty
+    full_state = dut.full_o.value.integer
+    empty_state = dut.empty_o.value.integer
+    check_result(full_state, 0)
+    check_result(empty_state, 1)
+
+    # For waveform purposes only
+    for i in range(10):
+        await clock_and_time(dut.clk_i)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "DataWidth": str(DATA_WIDTH),
+            "FifoDepth": str(FIFO_DEPTH),
+        }
+    ],
+)
+def test_fifo(simulator, parameters, waves):
+    verilog_sources = ["/rtl/common/fifo.sv"]
+
+    toplevel = "fifo"
+
+    module = "test_fifo"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -3,8 +3,8 @@
   Ryan Antonio <ryan.antonio@esat.kuleuven.be>
 
   Description:
-  This tests the basic functionality of the
-  register set with 1 write and 1 read port
+  This tests the basic functionality
+of the FIFO common module
 """
 
 from util import setup_and_run, gen_rand_bits, clock_and_time, check_result


### PR DESCRIPTION
This PR adds a FIFO common module. It is a derivative of the `pulp_platform` of `fifo_v3`. 

Major TODOs:
- [x] Add FIFO RTL
- [x] Add test for the FIFO RTL