### PR TITLE
This adds the item memory top including the FIFO that holds the registers

### DIFF
--- a/rtl/item_memory/item_memory_top.sv
+++ b/rtl/item_memory/item_memory_top.sv
@@ -1,0 +1,143 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Item Memory Top
+// Description:
+// This is the top-module of the item memory
+// it does a project and fetch mechanism
+// that coordinates directly with a data port
+//---------------------------
+
+module item_memory_top #(
+  parameter int unsigned HVDimension   = 512,
+  parameter int unsigned NumTotIm      = 1024,
+  parameter int unsigned NumPerImBank  = 128,
+  parameter int unsigned ImAddrWidth   = 32,
+  parameter int unsigned SeedWidth     = 32,
+  parameter int unsigned HoldFifoDepth = 2,
+  // Don't touch!
+  parameter int unsigned NumImSets     = NumTotIm/NumPerImBank
+)(
+  // Clock and resets
+  input  logic                                  clk_i,
+  input  logic                                  rst_ni,
+  // Configurations from CSR
+  input  logic                                  port_a_cim_i,
+  input  logic                [  SeedWidth-1:0] cim_seed_hv_i,
+  input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv_i,
+  // Enable signal for system enable
+  input  logic                                  en_i,
+  // Inputs from the fetcher side
+  input  logic                [ImAddrWidth-1:0] im_a_addr_i,
+  input  logic                                  im_a_addr_valid_i,
+  output logic                                  im_a_addr_ready_o,
+  input  logic                [ImAddrWidth-1:0] im_b_addr_i,
+  input  logic                                  im_b_addr_valid_i,
+  output logic                                  im_b_addr_ready_o,
+  // Outputs towards the encoder
+  output logic                [HVDimension-1:0] im_a_o,
+  input  logic                                  im_a_pop_i,
+  output logic                [HVDimension-1:0] im_b_o,
+  input  logic                                  im_b_pop_i
+);
+
+  //---------------------------
+  // Local parameters
+  //---------------------------
+  localparam int unsigned NumCimLevels = HVDimension/2;
+  localparam int unsigned CimSelWidth  = $clog2(NumCimLevels);
+  localparam int unsigned ImSelWidth   = $clog2(NumTotIm);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic [ImAddrWidth-1:0] im_a_addr, im_b_addr;
+
+  logic fifo_full_a, fifo_full_b;
+  logic fifo_empty_a, fifo_empty_b;
+
+  logic fifo_push_a, fifo_push_b;
+  logic fifo_pop_a, fifo_pop_b;
+
+  logic [HVDimension-1:0] im_a, im_b;
+
+  //---------------------------
+  // Combinational assignments
+  //---------------------------
+  assign im_a_addr_ready_o = !fifo_full_a;
+  assign im_b_addr_ready_o = !fifo_full_b;
+
+  assign fifo_push_a = im_a_addr_valid_i && im_a_addr_ready_o;
+  assign fifo_push_b = im_b_addr_valid_i && im_b_addr_ready_o;
+
+  assign fifo_pop_a  = im_a_pop_i && !fifo_empty_a;
+  assign fifo_pop_b  = im_b_pop_i && !fifo_empty_b;
+
+  //---------------------------
+  // Combinational item memory
+  //---------------------------
+  item_memory #(
+    .HVDimension   ( HVDimension   ),
+    .NumTotIm      ( NumTotIm      ),
+    .NumPerImBank  ( NumPerImBank  ),
+    .ImAddrWidth   ( ImAddrWidth   ),
+    .SeedWidth     ( SeedWidth     )
+  ) i_item_memory (
+    .port_a_cim_i  ( port_a_cim_i  ),
+    .cim_seed_hv_i ( cim_seed_hv_i ),
+    .im_seed_hv_i  ( im_seed_hv_i  ),
+    .im_a_addr_i   ( im_a_addr_i   ),
+    .im_b_addr_i   ( im_b_addr_i   ),
+    .im_a_o        ( im_a        ),
+    .im_b_o        ( im_b        )
+  );
+
+  //---------------------------
+  // FIFO for outputs
+  //---------------------------
+  fifo #(
+    .DataWidth       ( HVDimension   ),
+    .FifoDepth       ( HoldFifoDepth )
+  ) i_fifo_im_a (
+    // Clocks and reset
+    .clk_i           ( clk_i         ),
+    .rst_ni          ( rst_ni        ),
+    // Software synchronous clear
+    .clr_i           ( !en_i         ),
+    // Status flags
+    .full_o          ( fifo_full_a   ),
+    .empty_o         ( fifo_empty_a  ),
+    // Note that this counter state is index 1
+    .counter_state_o ( /*Unused*/    ),
+    // Input push
+    .data_i          ( im_a          ),
+    .push_i          ( fifo_push_a   ),
+    // Output pop
+    .data_o          ( im_a_o        ),
+    .pop_i           ( fifo_pop_a    )
+  );
+
+  fifo #(
+    .DataWidth       ( HVDimension   ),
+    .FifoDepth       ( HoldFifoDepth )
+  ) i_fifo_im_b (
+    // Clocks and reset
+    .clk_i           ( clk_i         ),
+    .rst_ni          ( rst_ni        ),
+    // Software synchronous clear
+    .clr_i           ( !en_i         ),
+    // Status flags
+    .full_o          ( fifo_full_b   ),
+    .empty_o         ( fifo_empty_b  ),
+    // Note that this counter state is index 1
+    .counter_state_o ( /*Unused*/    ),
+    // Input push
+    .data_i          ( im_b          ),
+    .push_i          ( fifo_push_b   ),
+    // Output pop
+    .data_o          ( im_b_o        ),
+    .pop_i           ( fifo_pop_b    )
+  );
+
+endmodule

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -22,6 +22,7 @@ CA90_MODE = "ca90_hier"
 
 # Instruction memory parameters
 INST_MEM_DEPTH = 128
+HOLD_FIFO_DEPTH = 4
 
 # Encoder parameters
 BUNDLER_COUNT_WIDTH = 8

--- a/tests/test_item_memory_top.py
+++ b/tests/test_item_memory_top.py
@@ -1,0 +1,234 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the memory holding FIFO
+"""
+
+import set_parameters
+import cocotb
+from cocotb.clock import Clock
+import pytest
+import sys
+
+from util import (
+    get_root,
+    setup_and_run,
+    check_result,
+    check_result_array,
+    numbin2list,
+    hvlist2num,
+    clock_and_time,
+)
+
+# Add hdc utility functions
+hdc_util_path = get_root() + "/hdc_exp/"
+sys.path.append(hdc_util_path)
+
+# Import item memory generations
+from hdc_util import gen_square_cim, gen_ca90_im_set  # noqa: E402
+
+
+# Working functions
+def clear_inputs_no_clock(dut):
+    # Initialize all other ports to 0
+    # Exclude seeds ports
+    dut.port_a_cim_i.value = 0
+
+    dut.im_a_addr_i.value = 0
+    dut.im_a_addr_valid_i.value = 0
+
+    dut.im_b_addr_i.value = 0
+    dut.im_b_addr_valid_i.value = 0
+
+    dut.im_a_pop_i.value = 0
+    dut.im_b_pop_i.value = 0
+
+    return
+
+
+async def load_im_addr(dut, addr, port="a"):
+    clear_inputs_no_clock(dut)
+    if port == "a":
+        dut.im_a_addr_i.value = addr
+        dut.im_a_addr_valid_i.value = 1
+    else:
+        dut.im_b_addr_i.value = addr
+        dut.im_b_addr_valid_i.value = 1
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return
+
+
+async def read_and_pop(dut, port="a"):
+    clear_inputs_no_clock(dut)
+    if port == "a":
+        im_val = dut.im_a_o.value.integer
+        dut.im_a_pop_i.value = 1
+    else:
+        im_val = dut.im_b_o.value.integer
+        dut.im_b_pop_i.value = 1
+
+    im_val = numbin2list(im_val, set_parameters.HV_DIM)
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return im_val
+
+
+@cocotb.test()
+async def item_memory_top_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("              Item Memory Top               ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("               Initial reset                ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+    dut.cim_seed_hv_i.value = 0
+    dut.im_seed_hv_i.value = 0
+    dut.en_i.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+
+    dut.rst_ni.value = 1
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("     Generate Seeds and Golden Values       ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Generated golden CiM
+    cim_seed_input, golden_cim = gen_square_cim(
+        hv_dim=set_parameters.HV_DIM,
+        seed_size=set_parameters.REG_FILE_WIDTH,
+        im_type=set_parameters.CA90_MODE,
+    )
+
+    # Convert seed list to number
+    cim_seed_input = hvlist2num(cim_seed_input)
+
+    # Generate seed list and golden IM
+    im_seed_input_list, golden_im, conf_mat = gen_ca90_im_set(
+        seed_size=set_parameters.REG_FILE_WIDTH,
+        hv_dim=set_parameters.HV_DIM,
+        num_total_im=set_parameters.NUM_TOT_IM,
+        num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        ca90_mode=set_parameters.CA90_MODE,
+    )
+
+    # For combining into a single
+    # wire bus for simulation purposes
+    num_im_banks = int(set_parameters.NUM_TOT_IM / set_parameters.NUM_PER_IM_BANK)
+    im_seed_input = 0
+    for i in range(num_im_banks):
+        im_seed_input = (
+            im_seed_input << set_parameters.REG_FILE_WIDTH
+        ) + im_seed_input_list[num_im_banks - i - 1]
+
+    # Input the CiM seed and the iM seeds
+    dut.cim_seed_hv_i.value = cim_seed_input
+    dut.im_seed_hv_i.value = im_seed_input
+
+    # Enable system too
+    dut.en_i.value = 1
+
+    # Propagate time for logic
+    await clock_and_time(dut.clk_i)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         Testing FIFO Capabilities          ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # First fill the entire buffer
+    for i in range(set_parameters.HOLD_FIFO_DEPTH):
+        await load_im_addr(dut, i, port="a")
+        await load_im_addr(dut, i, port="b")
+
+    # Since we filled the entire buffer
+    # we check if it's full and it should set
+    # the ready ports of the streamer side to 0
+    fifo_a_full = dut.im_a_addr_ready_o.value.integer
+    check_result(fifo_a_full, 0)
+
+    fifo_b_full = dut.im_b_addr_ready_o.value.integer
+    check_result(fifo_b_full, 0)
+
+    # For wave-form viewing purposes
+    clear_inputs_no_clock(dut)
+    await clock_and_time(dut.clk_i)
+
+    # Read and pop the outputs
+    for i in range(set_parameters.HOLD_FIFO_DEPTH):
+        # Read and check value firsts
+        im_a_val = await read_and_pop(dut, port="a")
+        check_result_array(im_a_val, golden_im[i])
+
+        im_b_val = await read_and_pop(dut, port="b")
+        check_result_array(im_b_val, golden_im[i])
+
+    # The FIFOs need to be empty at this point
+    # check if the ready signal is asserted
+    fifo_a_full = dut.im_a_addr_ready_o.value.integer
+    check_result(fifo_a_full, 1)
+
+    fifo_b_full = dut.im_b_addr_ready_o.value.integer
+    check_result(fifo_b_full, 1)
+
+    # This is for waveform checking later
+    for i in range(set_parameters.TEST_RUNS):
+        # Propagate time for logic
+        await clock_and_time(dut.clk_i)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "HVDimension": str(set_parameters.HV_DIM),
+            "NumTotIm": str(set_parameters.NUM_TOT_IM),
+            "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
+            "ImAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            "SeedWidth": str(set_parameters.REG_FILE_WIDTH),
+            "HoldFifoDepth": str(set_parameters.HOLD_FIFO_DEPTH),
+        }
+    ],
+)
+def test_item_memory_top(simulator, parameters):
+    verilog_sources = [
+        # Level 0
+        "/rtl/common/fifo.sv",
+        "/rtl/common/mux.sv",
+        "/rtl/item_memory/ca90_unit.sv",
+        "/rtl/item_memory/cim_bit_flip.sv",
+        # Level 1
+        "/rtl/item_memory/ca90_hier_base.sv",
+        # Level 2
+        "/rtl/item_memory/cim.sv",
+        "/rtl/item_memory/ca90_item_memory.sv",
+        # Level 3
+        "/rtl/item_memory/item_memory.sv",
+        # Level 4
+        "/rtl/item_memory/item_memory_top.sv",
+    ]
+
+    toplevel = "item_memory_top"
+
+    module = "test_item_memory_top"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=True,
+    )


### PR DESCRIPTION
This PR adds the item memory top as shown in:

![image](https://github.com/user-attachments/assets/54e28254-e55c-4d99-8112-065adf738ade)

The fetch unit is not included as it needs some careful designing. The purpose of this is to cut the combinational logic path of the item memory. Since it's a **data fetch** mechanism, then it makes sense that it is part of the **streaming** capabilities.

Major TODOs:
- [x] Make the top that combines the item memory and the FIFO
- [x] Make a test

Minor TODOs:
- [x] Some minor clean-ups