### PR TITLE
Add instruction loop control

### DIFF
--- a/rtl/inst_memory/inst_loop_control.sv
+++ b/rtl/inst_memory/inst_loop_control.sv
@@ -1,0 +1,178 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Instruction Loop Control
+// Description:
+// This module handles the instruction loop
+// counting and logic
+//---------------------------
+
+module inst_loop_control # (
+  parameter int unsigned InstMemAddrWidth = 32,
+  // Don't touch
+  parameter int unsigned LoopNumStates = 4,
+  parameter int unsigned LoopNumWidth  = $clog2(LoopNumStates)
+)(
+  // Clocks and reset
+  input  logic                         clk_i,
+  input  logic                         rst_ni,
+  // Control signals
+  input  logic                         clr_i,
+  input  logic                         en_i,
+  input  logic                         stall_i,
+  input  logic                         dbg_en_i,
+  // Program counter from inst control
+  input  logic [InstMemAddrWidth-1:0]  inst_pc_i,
+  // Loop control from CSR registers
+  input  logic [    LoopNumWidth-1:0]  inst_loop_mode_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_jump_addr1_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_jump_addr2_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_jump_addr3_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_end_addr1_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_end_addr2_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_end_addr3_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_count_addr1_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_count_addr2_i,
+  input  logic [InstMemAddrWidth-1:0]  inst_loop_count_addr3_i,
+  // Loop control signals
+  output logic                         inst_jump_o,
+  output logic [InstMemAddrWidth-1:0]  inst_jump_addr_o,
+  // Status signal
+  output logic                         inst_loop_done_o
+);
+
+  //---------------------------
+  // Logic and wires
+  //---------------------------
+  logic [InstMemAddrWidth-1:0] loop1_count, loop2_count, loop3_count;
+
+  logic loop1_hit_end_addr, loop2_hit_end_addr, loop3_hit_end_addr;
+  logic loop1_bound_end, loop2_bound_end, loop3_bound_end;
+
+  //---------------------------
+  // Assignments
+  //---------------------------
+  assign loop1_hit_end_addr = (inst_pc_i == inst_loop_end_addr1_i);
+  assign loop2_hit_end_addr = (inst_pc_i == inst_loop_end_addr2_i);
+  assign loop3_hit_end_addr = (inst_pc_i == inst_loop_end_addr3_i);
+
+  assign loop1_bound_end =  (loop1_count == (inst_loop_count_addr1_i-1));
+  assign loop2_bound_end =  (loop2_count == (inst_loop_count_addr2_i-1));
+  assign loop3_bound_end =  (loop3_count == (inst_loop_count_addr3_i-1));
+
+  //---------------------------
+  // Main counters
+  //
+  // Each counter increments if it hits an end address
+  // otherwise it stays but also resets when it hits an
+  // address and when it hits a loop count bound
+  //---------------------------
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+
+    if (!rst_ni) begin
+
+      loop1_count <= {InstMemAddrWidth{1'b0}};
+      loop2_count <= {InstMemAddrWidth{1'b0}};
+      loop3_count <= {InstMemAddrWidth{1'b0}};
+
+    end else begin
+
+      if (clr_i) begin
+
+        loop1_count <= {InstMemAddrWidth{1'b0}};
+        loop2_count <= {InstMemAddrWidth{1'b0}};
+        loop3_count <= {InstMemAddrWidth{1'b0}};
+
+      end else if (en_i && !stall_i && !dbg_en_i) begin
+
+        if (loop1_hit_end_addr && loop1_bound_end) begin
+          loop1_count <= {InstMemAddrWidth{1'b0}};
+        end else if (loop1_hit_end_addr) begin
+          loop1_count <= loop1_count + 1;
+        end else begin
+          loop1_count <= loop1_count;
+        end
+
+        if (loop2_hit_end_addr && loop2_bound_end) begin
+          loop2_count <= {InstMemAddrWidth{1'b0}};
+        end else if (loop2_hit_end_addr) begin
+          loop2_count <= loop2_count + 1;
+        end else begin
+          loop2_count <= loop2_count;
+        end
+
+        if (loop3_hit_end_addr && loop3_bound_end) begin
+          loop3_count <= {InstMemAddrWidth{1'b0}};
+        end else if (loop3_hit_end_addr) begin
+          loop3_count <= loop3_count + 1;
+        end else begin
+          loop3_count <= loop3_count;
+        end
+
+
+      end else begin
+
+        loop1_count <= {InstMemAddrWidth{1'b0}};
+        loop2_count <= {InstMemAddrWidth{1'b0}};
+        loop3_count <= {InstMemAddrWidth{1'b0}};
+
+      end
+    end
+  end
+
+  //---------------------------
+  // Output assignment
+  //---------------------------
+
+  // This handles when the output loop is completed
+  always_comb begin
+      case(inst_loop_mode_i)
+        default: begin
+          inst_loop_done_o = 1'b0;
+          inst_jump_o      = 1'b0;
+          inst_jump_addr_o = {InstMemAddrWidth{1'b0}};
+        end
+        2'b01: begin
+          inst_jump_o      = loop1_hit_end_addr && !loop1_bound_end;
+          inst_jump_addr_o = inst_loop_jump_addr1_i;
+          inst_loop_done_o = loop1_bound_end && loop1_hit_end_addr;
+        end
+
+        2'b10: begin
+          inst_jump_o      = (loop1_hit_end_addr && !loop1_bound_end) ||
+                             (loop2_hit_end_addr && !loop2_bound_end);
+
+          if (loop1_hit_end_addr && !loop1_bound_end) begin
+            inst_jump_addr_o = inst_loop_jump_addr1_i;
+          end else if (loop2_hit_end_addr && !loop2_bound_end) begin
+            inst_jump_addr_o = inst_loop_jump_addr2_i;
+          end else begin
+            inst_jump_addr_o = {InstMemAddrWidth{1'b0}};
+          end
+
+          inst_loop_done_o = loop2_bound_end && loop2_hit_end_addr;
+        end
+        2'b11: begin
+          inst_jump_o      = (loop1_hit_end_addr && !loop1_bound_end) ||
+                             (loop2_hit_end_addr && !loop2_bound_end) ||
+                             (loop3_hit_end_addr && !loop3_bound_end);
+
+          if (loop1_hit_end_addr && !loop1_bound_end) begin
+            inst_jump_addr_o = inst_loop_jump_addr1_i;
+          end else if (loop2_hit_end_addr && !loop2_bound_end) begin
+            inst_jump_addr_o = inst_loop_jump_addr2_i;
+          end else if (loop3_hit_end_addr && !loop3_bound_end) begin
+            inst_jump_addr_o = inst_loop_jump_addr3_i;
+          end else begin
+            inst_jump_addr_o = {InstMemAddrWidth{1'b0}};
+          end
+
+          inst_loop_done_o = loop3_bound_end && loop3_hit_end_addr;
+        end
+      endcase
+  end
+
+
+
+endmodule


### PR DESCRIPTION
This PR adds a hardware-managed loop control to configure the loops for the instruction decode. It is a 3D loop with specific CSRs. This is added to the main instruction control.

![image](https://github.com/user-attachments/assets/d1df9041-0ff0-4490-aed3-c83b21687bfe)

This module has a feature where we do memory access looping in the instruction memory. A similar concept of striding is in data memory. 

![image](https://github.com/user-attachments/assets/54335c38-2707-4d48-8ced-3f9af6d4b99a)

So the sample image above shows that we can set the jump and end addresses. Jump addresses are the automatic jump for the loop, while the end addresses are for the stopping points of the loop. The instruction loop control is a separate control that handles jump signals to the program counter. Each loop can be configured.

Major TODO:
- [x] RTL for instruction loop control
- [x] Attach it ton main instruction control module
- [x] Make test for this loop control
