### PR TITLE
Refactor QHV module and add am load signal

### DIFF
--- a/rtl/encoder/hv_encoder.sv
+++ b/rtl/encoder/hv_encoder.sv
@@ -49,9 +49,12 @@ module hv_encoder #(
   input  logic [RegAddrWidth-1:0] reg_wr_addr_i,
   input  logic                    reg_wr_en_i,
   // Control ports for query HV
-  input  logic                    qhv_clr_i,
   input  logic                    qhv_wen_i,
+  input  logic                    qhv_clr_i,
   input  logic [  QvMuxWidth-1:0] qhv_mux_i,
+  input  logic                    qhv_am_load_i,
+  input  logic                    qhv_ready_i,
+  output logic                    qhv_valid_o,
   output logic [ HVDimension-1:0] qhv_o
 );
 
@@ -221,19 +224,20 @@ module hv_encoder #(
   //---------------------------
   // Query HV register
   //---------------------------
-
-  always_ff @ (posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      qhv_o <= {HVDimension{1'b0}};
-    end else begin
-      if (qhv_clr_i) begin
-        qhv_o <= {HVDimension{1'b0}};
-      end else if ( qhv_wen_i ) begin
-        qhv_o <= qhv_input;
-      end else begin
-        qhv_o <= qhv_o;
-      end
-    end
-  end
+  qhv #(
+    .HVDimension   ( HVDimension   )
+  ) i_qhv (
+    // Clocks and reset
+    .clk_i         ( clk_i         ),
+    .rst_ni        ( rst_ni        ),
+    // Control ports for query HV
+    .qhv_i         ( qhv_input     ),
+    .qhv_wen_i     ( qhv_wen_i     ),
+    .qhv_clr_i     ( qhv_clr_i     ),
+    .qhv_am_load_i ( qhv_am_load_i ),
+    .qhv_o         ( qhv_o         ),
+    .qhv_valid_o   ( qhv_valid_o   ),
+    .qhv_ready_i   ( qhv_ready_i   )
+  );
 
 endmodule

--- a/rtl/encoder/qhv.sv
+++ b/rtl/encoder/qhv.sv
@@ -1,0 +1,68 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Encoder
+// Description:
+// Main encoder module including glue logic
+// for the registers, hypervector ALUs,
+// and other useful units.
+//---------------------------
+
+module qhv #(
+  parameter int unsigned HVDimension    = 512
+)(
+  // Clocks and reset
+  input  logic clk_i,
+  input  logic rst_ni,
+  // Control ports for query HV
+  input  logic [HVDimension-1:0] qhv_i,
+  input  logic                   qhv_wen_i,
+  input  logic                   qhv_clr_i,
+  input  logic                   qhv_am_load_i,
+  output logic [HVDimension-1:0] qhv_o,
+  output logic                   qhv_valid_o,
+  input  logic                   qhv_ready_i
+);
+
+  //---------------------------
+  // Query HV register
+  //---------------------------
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      qhv_o <= {HVDimension{1'b0}};
+    end else begin
+      if (qhv_clr_i) begin
+        qhv_o <= {HVDimension{1'b0}};
+      end else if (qhv_wen_i) begin
+        qhv_o <= qhv_i;
+      end else begin
+        qhv_o <= qhv_o;
+      end
+    end
+  end
+
+  //---------------------------
+  // Control for the valid-ready signals
+  //---------------------------
+
+  logic  qhv_load_success;
+  assign qhv_load_success = qhv_valid_o & qhv_ready_i;
+
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      qhv_valid_o <= 1'b0;
+    end else begin
+      if (qhv_clr_i) begin
+        qhv_valid_o <= 1'b0;
+      end else if (qhv_am_load_i) begin
+        qhv_valid_o <= 1'b1;
+      end else if (qhv_load_success) begin
+        qhv_valid_o <= 1'b0;
+      end else begin
+        qhv_valid_o <= qhv_valid_o;
+      end
+    end
+  end
+
+endmodule

--- a/tests/util.py
+++ b/tests/util.py
@@ -241,6 +241,8 @@ def clear_encode_inputs_no_clock(dut):
     dut.qhv_clr_i.value = 0
     dut.qhv_wen_i.value = 0
     dut.qhv_mux_i.value = 0
+    dut.qhv_am_load_i.value = 0
+    dut.qhv_ready_i.value = 0
 
     return
 


### PR DESCRIPTION
This PR refactors the QHV module and includes the AM load signal to deliver the QHV register to the AM streamer RW port.

Major TODO:
- [x] Create QHV module
- [x] Refactor encoder module
- [x] Test with QHV module in encoder module