### PR TITLE
Add IM from TCDM select ports to the CSR registers

### DIFF
--- a/rtl/csr/csr.sv
+++ b/rtl/csr/csr.sv
@@ -51,7 +51,8 @@ module csr import csr_addr_pkg::*; #(
   output logic                                      csr_start_o,
   input  logic                                      csr_busy_i,
   output logic                                      csr_seq_test_mode_o,
-  output logic                                      csr_port_a_cim_o,
+  output logic                  [1:0]               csr_port_a_cim_o,
+  output logic                                      csr_port_b_cim_o,
   output logic                                      csr_clr_o,
   // AM settings
   output logic [    RegDataWidth-1:0]               csr_am_num_pred_o,
@@ -136,13 +137,14 @@ module csr import csr_addr_pkg::*; #(
     case(csr_req_addr_i)
       CORE_SET_REG_ADDR: begin
         csr_rd_data = {
-                                                                // verilog_lint: waive-start line-length
-                                      {(RegDataWidth-5){1'b0}}, // [31:5] -- Unused
-                                                          1'b0, //    [4] WO Core clear (generates pulse)
-        csr_set[CORE_SET_REG_ADDR][ CORE_SET_IMA_CIM_BIT_ADDR], //    [3] RW IMA CiM
-        csr_set[CORE_SET_REG_ADDR][CORE_SET_SEQ_TEST_BIT_ADDR], //    [2] RW Sequential test
-                                                    csr_busy_i, //    [1] RO Busy
-                                                          1'b0  //    [0] WO Start Core (generates pulse)
+                                                                 // verilog_lint: waive-start line-length
+                                       {(RegDataWidth-5){1'b0}}, // [31:5] -- Unused
+                                                           1'b0, //    [6] WO Core clear (generates pulse)
+        csr_set[CORE_SET_REG_ADDR][  CORE_SET_IMB_MUX_BIT_ADDR], //    [5] RW IMB MUX
+        csr_set[CORE_SET_REG_ADDR][4:CORE_SET_IMA_MUX_BIT_ADDR], //    [4:3] RW IMA MUX
+        csr_set[CORE_SET_REG_ADDR][ CORE_SET_SEQ_TEST_BIT_ADDR], //    [2] RW Sequential test
+                                                     csr_busy_i, //    [1] RO Busy
+                                                           1'b0  //    [0] WO Start Core (generates pulse)
                                                                 // verilog_lint: waive-stop line-length
         };
       end
@@ -243,8 +245,9 @@ module csr import csr_addr_pkg::*; #(
     csr_clr_o                  = csr_write_req &&
                                 (csr_req_addr_i == CORE_SET_REG_ADDR) &&
                                  csr_req_data_i[CORE_SET_CORE_CLR_BIT_ADDR];
-    csr_seq_test_mode_o        = csr_set[CORE_SET_REG_ADDR][CORE_SET_SEQ_TEST_BIT_ADDR];
-    csr_port_a_cim_o           = csr_set[CORE_SET_REG_ADDR][CORE_SET_IMA_CIM_BIT_ADDR];
+    csr_seq_test_mode_o        = csr_set[CORE_SET_REG_ADDR][ CORE_SET_SEQ_TEST_BIT_ADDR];
+    csr_port_b_cim_o           = csr_set[CORE_SET_REG_ADDR][  CORE_SET_IMB_MUX_BIT_ADDR];
+    csr_port_a_cim_o           = csr_set[CORE_SET_REG_ADDR][4:CORE_SET_IMA_MUX_BIT_ADDR];
 
     //---------------------------
     // AM settings

--- a/rtl/csr/csr_addr_pkg.sv
+++ b/rtl/csr/csr_addr_pkg.sv
@@ -18,8 +18,9 @@ package csr_addr_pkg;
   localparam logic [ 4:0] CORE_SET_START_CORE_BIT_ADDR    = 5'd0;
   localparam logic [ 4:0] CORE_SET_BUSY_BIT_ADDR          = 5'd1;
   localparam logic [ 4:0] CORE_SET_SEQ_TEST_BIT_ADDR      = 5'd2;
-  localparam logic [ 4:0] CORE_SET_IMA_CIM_BIT_ADDR       = 5'd3;
-  localparam logic [ 4:0] CORE_SET_CORE_CLR_BIT_ADDR      = 5'd4;
+  localparam logic [ 4:0] CORE_SET_IMA_MUX_BIT_ADDR       = 5'd3;
+  localparam logic [ 4:0] CORE_SET_IMB_MUX_BIT_ADDR       = 5'd5;
+  localparam logic [ 4:0] CORE_SET_CORE_CLR_BIT_ADDR      = 5'd6;
 
   // AM Settings
   localparam logic [31:0] AM_NUM_PREDICT_REG_ADDR         = 32'd1;

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -95,6 +95,9 @@ async def csr_dut(dut):
     check_result(test_val, 1)
 
     test_val = dut.csr_port_a_cim_o.value.integer
+    check_result(test_val, 3)
+
+    test_val = dut.csr_port_b_cim_o.value.integer
     check_result(test_val, 1)
 
     test_val = dut.csr_clr_o.value.integer
@@ -111,6 +114,9 @@ async def csr_dut(dut):
     check_result(test_val, 1)
 
     test_val = dut.csr_port_a_cim_o.value.integer
+    check_result(test_val, 3)
+
+    test_val = dut.csr_port_b_cim_o.value.integer
     check_result(test_val, 1)
 
     test_val = dut.csr_clr_o.value.integer
@@ -118,7 +124,7 @@ async def csr_dut(dut):
 
     # Request read and check if values are correct for return value
     csr_read_val = await read_csr(dut, set_parameters.CORE_SET_REG_ADDR)
-    golden_val = int(0x0000_000E)
+    golden_val = int(0x0000_003E)
 
     check_result(csr_read_val, golden_val)
 


### PR DESCRIPTION
This PR is a small fix to add the IM select ports to the CSR registers. This lets us immediately stream the IM to be plugged into the encoder modules.

Major TODO:
- [x] Modify CSR signals
- [x] Modify CSR address bits
- [x] Add to the CSR test