### PR TITLE
Refactor MUXes in HV encoder

### DIFF
--- a/tests/test_hv_encoder.py
+++ b/tests/test_hv_encoder.py
@@ -284,6 +284,7 @@ async def hv_encoder_dut(dut):
 def test_hv_encoder(simulator, parameters, waves):
     verilog_sources = [
         # Level 0
+        "/rtl/common/mux.sv",
         "/rtl/common/reg_file_1w2r.sv",
         "/rtl/encoder/hv_alu_pe.sv",
         "/rtl/encoder/bundler_unit.sv",


### PR DESCRIPTION
This PR is a simple clean-up to refactor the MUXes in the `hv_encoder` file.

Major TODO:
- [x] Refactor muxes
- [x] Add mux to the test filelist