### PR TITLE
Add checking of enable signal in the instruction control

### DIFF
--- a/rtl/inst_memory/inst_control.sv
+++ b/rtl/inst_memory/inst_control.sv
@@ -23,6 +23,7 @@ module inst_control # (
   input  logic                    clr_i,
   input  logic                    start_i,
   input  logic                    stall_i,
+  output logic                    enable_o,
   // Instruction update signals
   input  logic                    inst_pc_reset_i,
   input  logic                    inst_wr_mode_i,
@@ -66,7 +67,7 @@ module inst_control # (
   // Make sure to expand to avoid synthesis errors
   assign inst_pc_o    = {{(RegAddrWidth-InstMemAddrWidth){1'b0}},program_counter};
   assign inst_rd_addr = (dbg_en_i) ? dbg_addr_i[InstMemAddrWidth-1:0] : program_counter;
-
+  assign enable_o     = enable_core;
 
   //---------------------------
   // Enable core register

--- a/tests/test_inst_control.py
+++ b/tests/test_inst_control.py
@@ -157,6 +157,10 @@ async def inst_control_dut(dut):
 
     dut.start_i.value = 0
 
+    # Check if core is enabled
+    enable_val = dut.enable_o.value.integer
+    check_result(enable_val, 1)
+
     for i in range(set_parameters.INST_MEM_DEPTH):
         # Extract the 1st data that is readily available
         pc_val = dut.inst_pc_o.value.integer
@@ -166,6 +170,11 @@ async def inst_control_dut(dut):
         check_result(inst_data_val, golden_data_list[i])
 
         await clock_and_time(dut.clk_i)
+
+    # Core should be finished at this time
+    # Check if core is disabled
+    enable_val = dut.enable_o.value.integer
+    check_result(enable_val, 0)
 
     # Redo the test but this time use the debug port
     cocotb.log.info(" ------------------------------------------ ")


### PR DESCRIPTION
This PR adds an enable signal in the instruction control. This gets connected to the FIFOs of the item memory.

Major TODO:
- [x] Add enable signal
- [x] Test enable signal