### PR TITLE
Add clear and enable signals to item memory top

### DIFF
--- a/rtl/item_memory/item_memory_top.sv
+++ b/rtl/item_memory/item_memory_top.sv
@@ -28,7 +28,8 @@ module item_memory_top #(
   input  logic                [  SeedWidth-1:0] cim_seed_hv_i,
   input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv_i,
   // Enable signal for system enable
-  input  logic                                  en_i,
+  input  logic                                  clr_i,
+  input  logic                                  enable_i,
   output logic                                  stall_o,
   // Inputs from the fetcher side
   input  logic                [ImAddrWidth-1:0] lowdim_a_data_i,
@@ -70,8 +71,8 @@ module item_memory_top #(
   //---------------------------
   // Combinational assignments
   //---------------------------
-  assign im_a_addr_ready_o = !fifo_full_a;
-  assign im_b_addr_ready_o = !fifo_full_b;
+  assign im_a_addr_ready_o = !fifo_full_a && enable_i;
+  assign im_b_addr_ready_o = !fifo_full_b && enable_i;
 
   assign fifo_push_a = im_a_addr_valid_i && im_a_addr_ready_o;
   assign fifo_push_b = im_b_addr_valid_i && im_b_addr_ready_o;
@@ -143,7 +144,7 @@ module item_memory_top #(
     .clk_i           ( clk_i         ),
     .rst_ni          ( rst_ni        ),
     // Software synchronous clear
-    .clr_i           ( !en_i         ),
+    .clr_i           ( clr_i         ),
     // Status flags
     .full_o          ( fifo_full_a   ),
     .empty_o         ( fifo_empty_a  ),
@@ -165,7 +166,7 @@ module item_memory_top #(
     .clk_i           ( clk_i         ),
     .rst_ni          ( rst_ni        ),
     // Software synchronous clear
-    .clr_i           ( !en_i         ),
+    .clr_i           ( clr_i         ),
     // Status flags
     .full_o          ( fifo_full_b   ),
     .empty_o         ( fifo_empty_b  ),

--- a/tests/test_item_memory_top.py
+++ b/tests/test_item_memory_top.py
@@ -35,6 +35,7 @@ from hdc_util import gen_square_cim, gen_ca90_im_set  # noqa: E402
 def clear_inputs_no_clock(dut):
     # Initialize all other ports to 0
     # Exclude CSR related ports
+    dut.clr_i.value = 0
 
     dut.lowdim_a_data_i.value = 0
     dut.highdim_a_data_i.value = 0
@@ -99,7 +100,7 @@ async def item_memory_top_dut(dut):
     dut.im_seed_hv_i.value = 0
     dut.port_a_cim_i.value = 0
     dut.port_b_cim_i.value = 0
-    dut.en_i.value = 0
+    dut.enable_i.value = 0
 
     # Initialize clock always
     clock = Clock(dut.clk_i, 10, units="ns")
@@ -147,7 +148,7 @@ async def item_memory_top_dut(dut):
     dut.im_seed_hv_i.value = im_seed_input
 
     # Enable system too
-    dut.en_i.value = 1
+    dut.enable_i.value = 1
 
     # Propagate time for logic
     await clock_and_time(dut.clk_i)


### PR DESCRIPTION
This PR refactors the clear and enable signals of the item memory top. A simple refactoring to match that of the main units.

Major TODO:
- [x] Add clear and refactor enable
- [x] Modify tests