### PR TITLE
Adding QHV stall signal

### DIFF
--- a/rtl/encoder/hv_encoder.sv
+++ b/rtl/encoder/hv_encoder.sv
@@ -55,7 +55,8 @@ module hv_encoder #(
   input  logic                    qhv_am_load_i,
   input  logic                    qhv_ready_i,
   output logic                    qhv_valid_o,
-  output logic [ HVDimension-1:0] qhv_o
+  output logic [ HVDimension-1:0] qhv_o,
+  output logic                    qhv_stall_o
 );
 
   //---------------------------
@@ -276,7 +277,8 @@ module hv_encoder #(
     .qhv_am_load_i ( qhv_am_load_i ),
     .qhv_o         ( qhv_o         ),
     .qhv_valid_o   ( qhv_valid_o   ),
-    .qhv_ready_i   ( qhv_ready_i   )
+    .qhv_ready_i   ( qhv_ready_i   ),
+    .qhv_stall_o   ( qhv_stall_o   )
   );
 
 endmodule

--- a/rtl/encoder/qhv.sv
+++ b/rtl/encoder/qhv.sv
@@ -22,7 +22,8 @@ module qhv #(
   input  logic                   qhv_am_load_i,
   output logic [HVDimension-1:0] qhv_o,
   output logic                   qhv_valid_o,
-  input  logic                   qhv_ready_i
+  input  logic                   qhv_ready_i,
+  output logic                   qhv_stall_o
 );
 
   //---------------------------
@@ -45,7 +46,6 @@ module qhv #(
   //---------------------------
   // Control for the valid-ready signals
   //---------------------------
-
   logic  qhv_load_success;
   assign qhv_load_success = qhv_valid_o & qhv_ready_i;
 
@@ -64,5 +64,12 @@ module qhv #(
       end
     end
   end
+
+  //---------------------------
+  // QHV logic stall
+  //---------------------------
+  // Stall happens when query is still loaded
+  // the valid signal indicates that previous write has not completed yet
+  assign qhv_stall_o = qhv_am_load_i && qhv_valid_o;
 
 endmodule

--- a/tests/test_hv_encoder.py
+++ b/tests/test_hv_encoder.py
@@ -242,6 +242,26 @@ async def hv_encoder_dut(dut):
     valid_val = dut.qhv_valid_o.value.integer
     check_result(valid_val, 1)
 
+    # Force an am load to see if the stall signal asserts
+    dut.qhv_am_load_i.value = 1
+
+    # Let time propagate
+    await clock_and_time(dut.clk_i)
+
+    # Check stall signal
+    stall_val = dut.qhv_stall_o.value.integer
+    check_result(stall_val, 1)
+
+    # Set back to 0
+    dut.qhv_am_load_i.value = 0
+
+    # Let time propagate again
+    await clock_and_time(dut.clk_i)
+
+    # Check stall signal
+    stall_val = dut.qhv_stall_o.value.integer
+    check_result(stall_val, 0)
+
     # Assert ready to pull it low
     dut.qhv_ready_i.value = 1
 


### PR DESCRIPTION
This PR adds the QHV stall signal. A stall happens when the valid is still asserted in the QHV. Chances are that it takes several cycles to encode something before getting into the TCDM. Therefore, the valid signal of the QHV block needs to be de-asserted before a new `am_load` signal.

Major TODO:
- [x] Add `qhv_stall` to the QHV block and the encoder
- [x] Add test checker for this