### PR TITLE
Cleanup to rename signals for consistency

### DIFF
--- a/rtl/item_memory/item_memory_top.sv
+++ b/rtl/item_memory/item_memory_top.sv
@@ -34,12 +34,12 @@ module item_memory_top #(
   // Inputs from the fetcher side
   input  logic                [ImAddrWidth-1:0] lowdim_a_data_i,
   input  logic                [HVDimension-1:0] highdim_a_data_i,
-  input  logic                                  im_a_addr_valid_i,
-  output logic                                  im_a_addr_ready_o,
+  input  logic                                  im_a_data_valid_i,
+  output logic                                  im_a_data_ready_o,
   input  logic                [ImAddrWidth-1:0] lowdim_b_data_i,
   input  logic                [HVDimension-1:0] highdim_b_data_i,
-  input  logic                                  im_b_addr_valid_i,
-  output logic                                  im_b_addr_ready_o,
+  input  logic                                  im_b_data_valid_i,
+  output logic                                  im_b_data_ready_o,
   // Outputs towards the encoder
   output logic                [HVDimension-1:0] im_a_o,
   input  logic                                  im_a_pop_i,
@@ -71,11 +71,11 @@ module item_memory_top #(
   //---------------------------
   // Combinational assignments
   //---------------------------
-  assign im_a_addr_ready_o = !fifo_full_a && enable_i;
-  assign im_b_addr_ready_o = !fifo_full_b && enable_i;
+  assign im_a_data_ready_o = !fifo_full_a && enable_i;
+  assign im_b_data_ready_o = !fifo_full_b && enable_i;
 
-  assign fifo_push_a = im_a_addr_valid_i && im_a_addr_ready_o;
-  assign fifo_push_b = im_b_addr_valid_i && im_b_addr_ready_o;
+  assign fifo_push_a = im_a_data_valid_i && im_a_data_ready_o;
+  assign fifo_push_b = im_b_data_valid_i && im_b_data_ready_o;
 
   assign fifo_pop_a  = im_a_pop_i && !fifo_empty_a;
   assign fifo_pop_b  = im_b_pop_i && !fifo_empty_b;

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -508,8 +508,8 @@ async def csr_dut(dut):
         {
             "NumTotIm": str(set_parameters.NUM_TOT_IM),
             "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
-            "RegDataWidth": str(set_parameters.REG_FILE_WIDTH),
-            "RegAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
+            "CsrAddrWidth": str(set_parameters.REG_FILE_WIDTH),
             "InstMemDepth": str(set_parameters.INST_MEM_DEPTH),
         }
     ],

--- a/tests/test_item_memory_top.py
+++ b/tests/test_item_memory_top.py
@@ -39,11 +39,11 @@ def clear_inputs_no_clock(dut):
 
     dut.lowdim_a_data_i.value = 0
     dut.highdim_a_data_i.value = 0
-    dut.im_a_addr_valid_i.value = 0
+    dut.im_a_data_valid_i.value = 0
 
     dut.lowdim_b_data_i.value = 0
     dut.highdim_b_data_i.value = 0
-    dut.im_b_addr_valid_i.value = 0
+    dut.im_b_data_valid_i.value = 0
 
     dut.im_a_pop_i.value = 0
     dut.im_b_pop_i.value = 0
@@ -57,13 +57,13 @@ async def load_im_addr(dut, data, port="a", high_dim=False, seq_exe=True):
             dut.highdim_a_data_i.value = data
         else:
             dut.lowdim_a_data_i.value = data
-        dut.im_a_addr_valid_i.value = 1
+        dut.im_a_data_valid_i.value = 1
     else:
         if high_dim:
             dut.highdim_b_data_i.value = data
         else:
             dut.lowdim_b_data_i.value = data
-        dut.im_b_addr_valid_i.value = 1
+        dut.im_b_data_valid_i.value = 1
     if seq_exe:
         await clock_and_time(dut.clk_i)
         clear_inputs_no_clock(dut)
@@ -165,10 +165,10 @@ async def item_memory_top_dut(dut):
     # Since we filled the entire buffer
     # we check if it's full and it should set
     # the ready ports of the streamer side to 0
-    fifo_a_full = dut.im_a_addr_ready_o.value.integer
+    fifo_a_full = dut.im_a_data_ready_o.value.integer
     check_result(fifo_a_full, 0)
 
-    fifo_b_full = dut.im_b_addr_ready_o.value.integer
+    fifo_b_full = dut.im_b_data_ready_o.value.integer
     check_result(fifo_b_full, 0)
 
     # For wave-form viewing purposes
@@ -186,10 +186,10 @@ async def item_memory_top_dut(dut):
 
     # The FIFOs need to be empty at this point
     # check if the ready signal is asserted
-    fifo_a_full = dut.im_a_addr_ready_o.value.integer
+    fifo_a_full = dut.im_a_data_ready_o.value.integer
     check_result(fifo_a_full, 1)
 
-    fifo_b_full = dut.im_b_addr_ready_o.value.integer
+    fifo_b_full = dut.im_b_data_ready_o.value.integer
     check_result(fifo_b_full, 1)
 
     cocotb.log.info(" ------------------------------------------ ")


### PR DESCRIPTION
This PR is just a minor clean-up to rename signals and parameters.

Clean-up list:
- [x] Rename CSR parameters of CSR module
- [x] Rename valid-ready signals of `item_memory_top`