### PR TITLE
Initialize the testbench to be used

### DIFF
--- a/rtl/tb/tb_hypercorex.sv
+++ b/rtl/tb/tb_hypercorex.sv
@@ -1,0 +1,319 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Testbench for Hypercorex
+// Description:
+// This module is the top-level testbench
+// for the Hypercorex accelerator
+//---------------------------
+
+module tb_hypercorex # (
+  //---------------------------
+  // General Parameters
+  //---------------------------
+  parameter int unsigned HVDimension      = 512,
+  //---------------------------
+  // CSR Parameters
+  //---------------------------
+  parameter int unsigned CsrDataWidth     = 32,
+  parameter int unsigned CsrAddrWidth     = 32,
+  //---------------------------
+  // Item Memory Parameters
+  //---------------------------
+  parameter int unsigned NumTotIm         = 1024,
+  parameter int unsigned NumPerImBank     = 128,
+  parameter int unsigned ImAddrWidth      = CsrDataWidth,
+  parameter int unsigned SeedWidth        = CsrDataWidth,
+  parameter int unsigned HoldFifoDepth    = 2,
+  //---------------------------
+  // Instruction Memory Parameters
+  //---------------------------
+  parameter int unsigned InstMemDepth     = 128,
+  //---------------------------
+  // HDC Encoder Parameters
+  //---------------------------
+  parameter int unsigned BundCountWidth   = 8,
+  parameter int unsigned BundMuxWidth     = 2,
+  parameter int unsigned ALUMuxWidth      = 2,
+  parameter int unsigned ALUMaxShiftAmt   = 128,
+  parameter int unsigned RegMuxWidth      = 2,
+  parameter int unsigned QvMuxWidth       = 2,
+  parameter int unsigned RegNum           = 4,
+  //---------------------------
+  // Don't touch!
+  //---------------------------
+  parameter int unsigned NumImSets        = NumTotIm/NumPerImBank,
+  parameter int unsigned InstMemAddrWidth = $clog2(InstMemDepth),
+  parameter int unsigned TbMemDepth       = 512,
+  parameter int unsigned TbMemAddrWidth   = CsrAddrWidth
+)(
+  //---------------------------
+  // Clocks and reset
+  //---------------------------
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+  //---------------------------
+  // CSR RW control signals
+  //---------------------------
+  // Request
+  input  logic [CsrDataWidth-1:0] csr_req_data_i,
+  input  logic [CsrAddrWidth-1:0] csr_req_addr_i,
+  input  logic                    csr_req_write_i,
+  input  logic                    csr_req_valid_i,
+  output logic                    csr_req_ready_o,
+  // Response
+  output logic [CsrDataWidth-1:0] csr_rsp_data_o,
+  input  logic                    csr_rsp_ready_i,
+  output logic                    csr_rsp_valid_o,
+  //---------------------------
+  // Memory module signals
+  //---------------------------
+  // Low or high dim mode
+  input  logic                      highdim_mode_i,
+  // Low dim signals
+  input  logic [TbMemAddrWidth-1:0] im_a_lowdim_wr_addr_i,
+  input  logic [  CsrDataWidth-1:0] im_a_lowdim_wr_data_i,
+  input  logic                      im_a_lowdim_wr_en_i,
+  input  logic [TbMemAddrWidth-1:0] im_a_lowdim_rd_addr_i,
+  output logic [  CsrDataWidth-1:0] im_a_lowdim_rd_data_o,
+
+  input  logic [TbMemAddrWidth-1:0] im_b_lowdim_wr_addr_i,
+  input  logic [  CsrDataWidth-1:0] im_b_lowdim_wr_data_i,
+  input  logic                      im_b_lowdim_wr_en_i,
+  input  logic [TbMemAddrWidth-1:0] im_b_lowdim_rd_addr_i,
+  output logic [  CsrDataWidth-1:0] im_b_lowdim_rd_data_o,
+  // High dim signals
+  input  logic [TbMemAddrWidth-1:0] im_a_highdim_wr_addr_i,
+  input  logic [   HVDimension-1:0] im_a_highdim_wr_data_i,
+  input  logic                      im_a_highdim_wr_en_i,
+  input  logic [TbMemAddrWidth-1:0] im_a_highdim_rd_addr_i,
+  output logic [   HVDimension-1:0] im_a_highdim_rd_data_o,
+
+  input  logic [TbMemAddrWidth-1:0] im_b_highdim_wr_addr_i,
+  input  logic [   HVDimension-1:0] im_b_highdim_wr_data_i,
+  input  logic                      im_b_highdim_wr_en_i,
+  input  logic [TbMemAddrWidth-1:0] im_b_highdim_rd_addr_i,
+  output logic [   HVDimension-1:0] im_b_highdim_rd_data_o,
+
+  // AM signals
+  input  logic [TbMemAddrWidth-1:0] am_wr_addr_i,
+  input  logic [   HVDimension-1:0] am_wr_data_i,
+  input  logic                      am_wr_en_i,
+  input  logic [TbMemAddrWidth-1:0] am_rd_addr_i,
+  input  logic [TbMemAddrWidth-1:0] am_auto_loop_addr_i,
+  output logic [   HVDimension-1:0] am_rd_data_o,
+  // QHV signals
+  input  logic [TbMemAddrWidth-1:0] qhv_rd_addr_i,
+  output logic [   HVDimension-1:0] qhv_rd_data_o,
+  // Enable signal for memory
+  input  logic                      enable_mem_i
+);
+
+  //---------------------------
+  // Wires and Logic
+  //---------------------------
+  logic [ ImAddrWidth-1:0] lowdim_a_data;
+  logic [ HVDimension-1:0] highdim_a_data;
+  logic                    im_a_data_valid;
+  logic                    im_a_data_ready;
+
+  logic [ ImAddrWidth-1:0] lowdim_b_data;
+  logic [ HVDimension-1:0] highdim_b_data;
+  logic                    im_b_data_valid;
+  logic                    im_b_data_ready;
+
+  logic                    qhv_ready;
+  logic                    qhv_valid;
+  logic [ HVDimension-1:0] qhv;
+
+  logic [ HVDimension-1:0] class_hv;
+  logic                    class_hv_valid;
+  logic                    class_hv_ready;
+
+  logic                    im_a_lowdim_valid;
+  logic                    im_a_highdim_valid;
+  logic                    im_a_valid;
+
+  logic                    im_b_lowdim_valid;
+  logic                    im_b_highdim_valid;
+  logic                    im_b_valid;
+
+  //---------------------------
+  // Depending on Mode to Test
+  //---------------------------
+  assign im_a_data_valid = highdim_mode_i ? im_a_highdim_valid : im_a_lowdim_valid;
+  assign im_b_data_valid = highdim_mode_i ? im_b_highdim_valid : im_b_lowdim_valid;
+
+  //---------------------------
+  // Memory Modules
+  //---------------------------
+
+  // Memory module for low dimensional memory IM A
+  tb_rd_memory # (
+    .DataWidth              ( CsrDataWidth          ),
+    .AddrWidth              ( CsrAddrWidth          ),
+    .MemDepth               ( TbMemDepth            )
+  ) i_im_a_lowdim_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                 ),
+    .rst_ni                 ( rst_ni                ),
+    // Enable signal
+    .en_i                   ( enable_mem_i          ),
+    // Write port
+    .wr_addr_i              ( im_a_lowdim_wr_addr_i ),
+    .wr_data_i              ( im_a_lowdim_wr_data_i ),
+    .wr_en_i                ( im_a_lowdim_wr_en_i   ),
+    // Read port
+    .rd_addr_i              ( im_a_lowdim_rd_addr_i ),
+    .rd_data_o              ( im_a_lowdim_rd_data_o ),
+    // Automatic loop mode
+    .auto_loop_addr_i       ( '0                    ),
+    .auto_loop_en_i         ( '0                    ),
+    // Accelerator access port
+    .rd_acc_addr_o          (                       ),
+    .rd_acc_data_o          ( lowdim_a_data         ),
+    .rd_acc_valid_o         ( im_a_lowdim_valid     ),
+    .rd_acc_ready_i         ( im_a_data_ready       )
+  );
+
+  // Memory module for high dimensional memory IM B
+  tb_rd_memory # (
+    .DataWidth              ( HVDimension            ),
+    .AddrWidth              ( CsrAddrWidth           ),
+    .MemDepth               ( TbMemDepth             )
+  ) i_im_a_highdim_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                  ),
+    .rst_ni                 ( rst_ni                 ),
+    // Enable signal
+    .en_i                   ( enable_mem_i           ),
+    // Write port
+    .wr_addr_i              ( im_a_highdim_wr_addr_i ),
+    .wr_data_i              ( im_a_highdim_wr_data_i ),
+    .wr_en_i                ( im_a_highdim_wr_en_i   ),
+    // Read port
+    .rd_addr_i              ( im_a_highdim_rd_addr_i ),
+    .rd_data_o              ( im_a_highdim_rd_data_o ),
+    // Automatic loop mode
+    .auto_loop_addr_i       ( '0                     ),
+    .auto_loop_en_i         ( '0                     ),
+    // Accelerator access port
+    .rd_acc_addr_o          (                        ),
+    .rd_acc_data_o          ( highdim_a_data         ),
+    .rd_acc_valid_o         ( im_a_highdim_valid     ),
+    .rd_acc_ready_i         ( im_a_data_ready        )
+  );
+
+  // Memory module for low dimensional memory IM B
+  tb_rd_memory # (
+    .DataWidth              ( CsrDataWidth          ),
+    .AddrWidth              ( CsrAddrWidth          ),
+    .MemDepth               ( TbMemDepth            )
+  ) i_im_b_lowdim_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                 ),
+    .rst_ni                 ( rst_ni                ),
+    // Enable signal
+    .en_i                   ( enable_mem_i          ),
+    // Write port
+    .wr_addr_i              ( im_b_lowdim_wr_addr_i ),
+    .wr_data_i              ( im_b_lowdim_wr_data_i ),
+    .wr_en_i                ( im_b_lowdim_wr_en_i   ),
+    // Read port
+    .rd_addr_i              ( im_b_lowdim_rd_addr_i ),
+    .rd_data_o              ( im_b_lowdim_rd_data_o ),
+    // Automatic loop mode
+    .auto_loop_addr_i       ( '0                    ),
+    .auto_loop_en_i         ( '0                    ),
+    // Accelerator access port
+    .rd_acc_addr_o          (                       ),
+    .rd_acc_data_o          ( lowdim_b_data         ),
+    .rd_acc_valid_o         ( im_b_lowdim_valid     ),
+    .rd_acc_ready_i         ( im_b_data_ready       )
+  );
+
+  // Memory module for high dimensional memory IM B
+  tb_rd_memory # (
+    .DataWidth              ( HVDimension            ),
+    .AddrWidth              ( CsrAddrWidth           ),
+    .MemDepth               ( TbMemDepth             )
+  ) i_im_b_highdim_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                  ),
+    .rst_ni                 ( rst_ni                 ),
+    // Enable signal
+    .en_i                   ( enable_mem_i           ),
+    // Write port
+    .wr_addr_i              ( im_b_highdim_wr_addr_i ),
+    .wr_data_i              ( im_b_highdim_wr_data_i ),
+    .wr_en_i                ( im_b_highdim_wr_en_i   ),
+    // Read port
+    .rd_addr_i              ( im_b_highdim_rd_addr_i ),
+    .rd_data_o              ( im_b_highdim_rd_data_o ),
+    // Automatic loop mode
+    .auto_loop_addr_i       ( '0                     ),
+    .auto_loop_en_i         ( '0                     ),
+    // Accelerator access port
+    .rd_acc_addr_o          (                        ),
+    .rd_acc_data_o          ( highdim_b_data         ),
+    .rd_acc_valid_o         ( im_b_highdim_valid     ),
+    .rd_acc_ready_i         ( im_b_data_ready        )
+  );
+
+  // Memory module for associative memory
+  tb_rd_memory # (
+    .DataWidth              ( HVDimension          ),
+    .AddrWidth              ( CsrAddrWidth         ),
+    .MemDepth               ( TbMemDepth           )
+  ) i_am_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                ),
+    .rst_ni                 ( rst_ni               ),
+    // Enable signal
+    .en_i                   ( enable_mem_i         ),
+    // Write port
+    .wr_addr_i              ( am_wr_addr_i         ),
+    .wr_data_i              ( am_wr_data_i         ),
+    .wr_en_i                ( am_wr_en_i           ),
+    // Read port
+    .rd_addr_i              ( am_rd_addr_i         ),
+    .rd_data_o              ( am_rd_data_o         ),
+    // Automatic loop mode
+    .auto_loop_addr_i       ( am_auto_loop_addr_i  ),
+    .auto_loop_en_i         ( 1'b1                 ),
+    // Accelerator access port
+    .rd_acc_addr_o          (                      ),
+    .rd_acc_data_o          ( class_hv             ),
+    .rd_acc_valid_o         ( class_hv_valid       ),
+    .rd_acc_ready_i         ( class_hv_ready       )
+  );
+
+  //---------------------------
+  // QHV write memory
+  //---------------------------
+  tb_wr_memory # (
+    .DataWidth              ( HVDimension          ),
+    .AddrWidth              ( CsrAddrWidth         ),
+    .MemDepth               ( TbMemDepth           )
+  ) i_qhv_memory (
+    // Clock and reset
+    .clk_i                  ( clk_i                ),
+    .rst_ni                 ( rst_ni               ),
+    // Enable signal
+    .en_i                   ( enable_mem_i         ),
+    // Read port
+    .rd_addr_i              ( qhv_rd_addr_i        ),
+    .rd_data_o              ( qhv_rd_data_o        ),
+    // Force address to be written
+    .set_wr_addr_i          ( '0                   ),
+    .set_wr_en_i            ( '0                   ),
+    // Accelerator access port
+    .wr_acc_addr_o          (                      ),
+    .wr_acc_data_i          ( qhv                  ),
+    .wr_acc_valid_i         ( qhv_valid            ),
+    .wr_acc_ready_o         ( qhv_ready            )
+  );
+
+
+endmodule

--- a/rtl/tb/tb_rd_memory.sv
+++ b/rtl/tb/tb_rd_memory.sv
@@ -1,0 +1,133 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Testbench Read Memory
+// Description:
+// This module is used to simulate a
+// continuous memory module
+//
+// Externally we can read and write
+// to the memory but the ports connected
+// to the core are read only
+//
+// The access to the accelerator is auto
+// incremented every time
+//---------------------------
+
+module tb_rd_memory # (
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned AddrWidth = 32,
+  parameter int unsigned MemDepth  = 1024
+)(
+  // Clock and reset
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+  // Enable signal
+  input  logic                    en_i,
+  // Write port
+  input  logic [AddrWidth-1:0]    wr_addr_i,
+  input  logic [DataWidth-1:0]    wr_data_i,
+  input  logic                    wr_en_i,
+  // Read port
+  input  logic [AddrWidth-1:0]    rd_addr_i,
+  output logic [DataWidth-1:0]    rd_data_o,
+  // Automatic loop mode
+  input  logic [AddrWidth-1:0]    auto_loop_addr_i,
+  input  logic                    auto_loop_en_i,
+  // Accelerator access port
+  output logic [AddrWidth-1:0]    rd_acc_addr_o,
+  output logic [DataWidth-1:0]    rd_acc_data_o,
+  output logic                    rd_acc_valid_o,
+  input  logic                    rd_acc_ready_i
+);
+
+  //---------------------------
+  // Wires and logic
+  //---------------------------
+  logic [MemDepth-1:0][DataWidth-1:0] mem;
+
+  //---------------------------
+  // Memory update
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      for (int i=0; i<MemDepth; i++) begin
+        mem[i] <= 0;
+      end
+    end else begin
+      if (wr_en_i) begin
+        mem[wr_addr_i] <= wr_data_i;
+      end
+    end
+  end
+
+  //---------------------------
+  // Memory read
+  //---------------------------
+  assign rd_data_o = mem[rd_addr_i];
+
+  //---------------------------
+  // Accelerator access
+  //---------------------------
+  logic [AddrWidth-1:0] acc_addr;
+  logic acc_success;
+
+  assign acc_success = rd_acc_valid_o && rd_acc_ready_i ;
+
+  logic auto_loop_end;
+
+  assign auto_loop_end = auto_loop_addr_i == acc_addr - 1;
+
+  //---------------------------
+  // Automated address counter
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      acc_addr <= 0;
+    end else begin
+      if (en_i) begin
+        // Update counter for every successful transaction
+        if (acc_success) begin
+
+          // If auto loop is enabled and the end address is reached
+          // reset the counter to 0 else increment the counter
+          if (auto_loop_end && auto_loop_en_i) begin
+            acc_addr <= '0;
+          end else begin
+            acc_addr <= acc_addr + 1;
+          end
+
+        end else begin
+          acc_addr <= acc_addr;
+        end
+      end else begin
+        acc_addr <= 0;
+      end
+    end
+  end
+
+  // Output data will always be valid
+  // in this synthetic memory read module
+  // since contentions will never happend
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_acc_data_o  <= 0;
+      rd_acc_valid_o <= 0;
+    end else begin
+      if (en_i) begin
+        rd_acc_data_o  <= mem[acc_addr];
+        rd_acc_valid_o <= 1;
+      end else begin
+        rd_acc_data_o  <= 0;
+        rd_acc_valid_o <= 0;
+      end
+    end
+  end
+
+  //---------------------------
+  // Output assignments
+  //---------------------------
+  assign rd_acc_addr_o   = acc_addr;
+
+endmodule

--- a/rtl/tb/tb_wr_memory.sv
+++ b/rtl/tb/tb_wr_memory.sv
@@ -1,0 +1,97 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Testbench Write Memory
+// Description:
+// This module is used to simulate a
+// continuous memory module
+//
+// It is being continuously written to
+// and external control simply reads from it
+//
+// There is capability to overwrite the memory
+// address to which the data is written to
+//---------------------------
+
+module tb_wr_memory # (
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned AddrWidth = 32,
+  parameter int unsigned MemDepth  = 1024
+)(
+  // Clock and reset
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+  // Enable signal
+  input  logic                    en_i,
+  // Read port
+  input  logic [AddrWidth-1:0]    rd_addr_i,
+  output logic [DataWidth-1:0]    rd_data_o,
+  // Force address to be written
+  input  logic [AddrWidth-1:0]    set_wr_addr_i,
+  input  logic                    set_wr_en_i,
+  // Accelerator access port
+  output logic [AddrWidth-1:0]    wr_acc_addr_o,
+  input  logic [DataWidth-1:0]    wr_acc_data_i,
+  input  logic                    wr_acc_valid_i,
+  output logic                    wr_acc_ready_o
+);
+
+  //---------------------------
+  // Wires and logic
+  //---------------------------
+  logic [MemDepth-1:0][DataWidth-1:0] mem;
+
+  logic wr_acc_success;
+
+  assign wr_acc_success = wr_acc_valid_i & wr_acc_ready_o;
+
+  //---------------------------
+  // Automatic address counter
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      wr_acc_addr_o <= '0;
+    end else begin
+      if (set_wr_en_i) begin
+            wr_acc_addr_o <= set_wr_addr_i;
+      end else if(en_i) begin
+        if (wr_acc_success) begin
+          wr_acc_addr_o <= wr_acc_addr_o + 1;
+        end else begin
+          wr_acc_addr_o <= wr_acc_addr_o;
+        end
+      end else begin
+        wr_acc_addr_o <= wr_acc_addr_o;
+      end
+    end
+  end
+
+  //---------------------------
+  // Memory update
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      for (int i=0; i<MemDepth; i++) begin
+        mem[i] <= 0;
+      end
+    end else begin
+      if (en_i) begin
+        if (wr_acc_success) begin
+          mem[wr_acc_addr_o] <= wr_acc_data_i;
+        end
+      end
+    end
+  end
+
+  //---------------------------
+  // Memory read
+  //---------------------------
+  assign rd_data_o = mem[rd_addr_i];
+
+  //---------------------------
+  // Accelerator ready port
+  //---------------------------
+  assign wr_acc_ready_o = en_i;
+
+endmodule

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -21,6 +21,7 @@ REG_FILE_WIDTH = 32
 NUM_TOT_IM = 256
 NUM_PER_IM_BANK = int(HV_DIM // 4)
 CA90_MODE = "ca90_hier"
+IM_FIFO_DEPTH = 2
 
 # Instruction memory parameters
 INST_MEM_WIDTH = REG_FILE_WIDTH

--- a/tests/test_tb_hypercorex.py
+++ b/tests/test_tb_hypercorex.py
@@ -1,0 +1,176 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the vectorized bundler unit
+"""
+
+import set_parameters
+from util import (
+    # General imports
+    get_root,
+    setup_and_run,
+    gen_rand_bits,
+    clock_and_time,
+    check_result_list,
+    # Testbench functions
+    clear_tb_inputs,
+    load_im_list,
+    read_im_list,
+    load_am_list,
+    read_am_list,
+)
+
+import cocotb
+from cocotb.clock import Clock
+import sys
+import pytest
+
+# Add hdc utility functions
+hdc_util_path = get_root() + "/hdc_exp/"
+print(hdc_util_path)
+sys.path.append(hdc_util_path)
+
+
+# Some local parameters
+
+
+# Actual test routines
+@cocotb.test()
+async def tb_hypercorex_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("              Testing Hypercorex            ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize input values
+    clear_tb_inputs(dut)
+
+    # Reset always
+    dut.rst_ni.value = 0
+
+    # Initialize hard static values
+    dut.am_auto_loop_addr_i.value = 0
+    dut.enable_mem_i.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+
+    dut.rst_ni.value = 1
+
+    # Initialize golden values
+    golden_im_a_lowdim_data = []
+    golden_im_a_highdim_data = []
+    golden_im_b_lowdim_data = []
+    golden_im_b_highdim_data = []
+    golden_am_data = []
+
+    for i in range(set_parameters.TEST_RUNS):
+        golden_im_a_lowdim_data.append(gen_rand_bits(set_parameters.REG_FILE_WIDTH))
+        golden_im_a_highdim_data.append(gen_rand_bits(set_parameters.HV_DIM))
+        golden_im_b_lowdim_data.append(gen_rand_bits(set_parameters.REG_FILE_WIDTH))
+        golden_im_b_highdim_data.append(gen_rand_bits(set_parameters.HV_DIM))
+        golden_am_data.append(gen_rand_bits(set_parameters.REG_FILE_WIDTH))
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Loading Data Unto IMs             ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Load data unto IMs
+    await load_im_list(dut, golden_im_a_lowdim_data, 0, "A", "low")
+    await load_im_list(dut, golden_im_a_highdim_data, 0, "A", "high")
+    await load_im_list(dut, golden_im_b_lowdim_data, 0, "B", "low")
+    await load_im_list(dut, golden_im_b_highdim_data, 0, "B", "high")
+    await load_am_list(dut, golden_am_data, 0)
+
+    # Sanity check to see if data is correctly loaded
+    actual_lowdim_im_a_list = await read_im_list(
+        dut, 0, set_parameters.TEST_RUNS, "A", "low"
+    )
+    actual_highdim_im_a_list = await read_im_list(
+        dut, 0, set_parameters.TEST_RUNS, "A", "high"
+    )
+    actual_lowdim_im_b_list = await read_im_list(
+        dut, 0, set_parameters.TEST_RUNS, "B", "low"
+    )
+    actual_highdim_im_b_list = await read_im_list(
+        dut, 0, set_parameters.TEST_RUNS, "B", "high"
+    )
+    actual_am_list = await read_am_list(dut, 0, set_parameters.TEST_RUNS)
+
+    # Check if data is correctly loaded
+    check_result_list(golden_im_a_lowdim_data, actual_lowdim_im_a_list)
+    check_result_list(golden_im_a_highdim_data, actual_highdim_im_a_list)
+    check_result_list(golden_im_b_lowdim_data, actual_lowdim_im_b_list)
+    check_result_list(golden_im_b_highdim_data, actual_highdim_im_b_list)
+    check_result_list(golden_am_data, actual_am_list)
+
+    # Some trailing cycles only
+    for i in range(10):
+        await clock_and_time(dut.clk_i)
+
+
+# Config and run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            # General parameters
+            "HVDimension": str(set_parameters.HV_DIM),
+            # CSR parameters
+            "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
+            "CsrAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            # Item memory parameters
+            "NumTotIm": str(set_parameters.NUM_TOT_IM),
+            "NumPerImBank": str(set_parameters.NUM_PER_IM_BANK),
+            "ImAddrWidth": str(set_parameters.REG_FILE_WIDTH),
+            "SeedWidth": str(set_parameters.REG_FILE_WIDTH),
+            "HoldFifoDepth": str(set_parameters.IM_FIFO_DEPTH),
+            # Instruction memory parameters
+            "InstMemDepth": str(set_parameters.INST_MEM_DEPTH),
+            # HDC encoder parameters
+            "BundCountWidth": str(set_parameters.BUNDLER_COUNT_WIDTH),
+            "BundMuxWidth": str(set_parameters.BUNDLER_MUX_WIDTH),
+            "ALUMuxWidth": str(set_parameters.ALU_MUX_WIDTH),
+            "ALUMaxShiftAmt": str(set_parameters.ALU_MAX_SHIFT),
+            "RegMuxWidth": str(set_parameters.REG_MUX_WIDTH),
+            "QvMuxWidth": str(set_parameters.QHV_MUX_WIDTH),
+            "RegNum": str(set_parameters.REG_NUM),
+        }
+    ],
+)
+def test_tb_hypercorex(simulator, parameters, waves):
+    verilog_sources = [
+        # Level 0
+        "/rtl/tb/tb_rd_memory.sv",
+        "/rtl/tb/tb_wr_memory.sv",
+        # Level 10
+        "/rtl/tb/tb_hypercorex.sv",
+        # # Level 0
+        # "/rtl/common/mux.sv",
+        # "/rtl/common/reg_file_1w2r.sv",
+        # "/rtl/encoder/hv_alu_pe.sv",
+        # "/rtl/encoder/bundler_unit.sv",
+        # "/rtl/encoder/qhv.sv",
+        # # Level 1
+        # "/rtl/encoder/bundler_set.sv",
+        # # Level 2
+        # "/rtl/encoder/hv_encoder.sv",
+    ]
+
+    toplevel = "tb_hypercorex"
+
+    module = "test_tb_hypercorex"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )


### PR DESCRIPTION
In this PR we create the testbench to be used for the hypercorex. Visually it looks:

![image](https://github.com/user-attachments/assets/b3a515ab-5401-4717-9763-8f66706a1cad)

It contains 6 different memory modules. Namely:

- Lowdim IM A
- Lowdim IM B
- Highdim IM A
- Highdim IM B
- AM
- QHV

The QHV is the only write testbench memory while the others are read memory. The read memories can be written by the `cocotb` modules. The QHV memory can only be written by the core later. The memories serve as ideal places where data is fed directly to the accelerator core.

It simulates what happens when data is readily available.

Major TODO:
- [x] Make `tb_rd_memory.sv`
- [x] Make `tb_wr_memory.sv`
- [x] Make `tb_hypercorex.sv` > the initial version of it
- [x] Make an initial test that compiles these modules.


