### PR TITLE
Fix RTL bugs

### DIFF
--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -229,7 +229,7 @@ module hypercorex_top # (
     //---------------------------
     // Core settings
     .csr_start_o                ( start                 ),
-    .csr_busy_i                 ( busy                  ),
+    .csr_busy_i                 ( enable                ),
     .csr_seq_test_mode_o        ( seq_test_mode         ),
     .csr_port_a_cim_o           ( port_a_cim            ),
     .csr_port_b_cim_o           ( port_b_cim            ),
@@ -328,7 +328,8 @@ module hypercorex_top # (
     .RegNum                     ( RegNum               )
   ) i_inst_decode (
     // Input instruction
-    .inst_code_i                ( inst_pc              ),
+    .inst_code_i                ( inst_at_addr         ),
+    .enable_i                   ( enable               ),
     // Control ports for IM
     .im_a_pop_o                 ( im_a_pop             ),
     .im_b_pop_o                 ( im_b_pop             ),

--- a/rtl/inst_memory/inst_decode.sv
+++ b/rtl/inst_memory/inst_decode.sv
@@ -34,6 +34,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
 )(
   // Input instruction
   input  logic [   InstWidth-1:0] inst_code_i,
+  input  logic                    enable_i,
   // Control ports for IM
   output logic                    im_a_pop_o,
   output logic                    im_b_pop_o,
@@ -65,21 +66,21 @@ module inst_decode import hypercorex_inst_pkg::*; #(
 );
 
   //---------------------------
-  // Local parameters
-  //---------------------------
-
-  //---------------------------
   // Wiring
   //---------------------------
+  logic [InstWidth-1:0] inst_code;
 
 
   //---------------------------
-  // Slice assignments
+  // Assignments
   //---------------------------
-  assign reg_rd_addr_b_o = inst_code_i[1:0];
-  assign reg_rd_addr_a_o = inst_code_i[3:2];
-  assign reg_wr_addr_o   = inst_code_i[5:4];
-  assign alu_shift_amt_o = inst_code_i[7:6];
+  assign reg_rd_addr_b_o = inst_code[1:0];
+  assign reg_rd_addr_a_o = inst_code[3:2];
+  assign reg_wr_addr_o   = inst_code[5:4];
+  assign alu_shift_amt_o = inst_code[7:6];
+
+  // For disabling the control signals if not yet used
+  assign inst_code = (enable_i) ? inst_code_i : {InstWidth{1'b0}};
 
   //---------------------------
   // Main instruction decoder
@@ -122,7 +123,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
     am_search_o = '0;
     am_load_o   = '0;
 
-    unique casez (inst_code_i)
+    unique casez (inst_code)
       // Default for when unknown instructions come in
       default: begin
         // Contorl ports for IM

--- a/rtl/item_memory/item_memory_top.sv
+++ b/rtl/item_memory/item_memory_top.sv
@@ -137,6 +137,7 @@ module item_memory_top #(
   // FIFO for outputs
   //---------------------------
   fifo #(
+    .FallThrough     ( 1'b1          ),
     .DataWidth       ( HVDimension   ),
     .FifoDepth       ( HoldFifoDepth )
   ) i_fifo_im_a (
@@ -159,6 +160,7 @@ module item_memory_top #(
   );
 
   fifo #(
+    .FallThrough     ( 1'b1          ),
     .DataWidth       ( HVDimension   ),
     .FifoDepth       ( HoldFifoDepth )
   ) i_fifo_im_b (

--- a/rtl/tb/tb_rd_memory.sv
+++ b/rtl/tb/tb_rd_memory.sv
@@ -110,19 +110,16 @@ module tb_rd_memory # (
   // Output data will always be valid
   // in this synthetic memory read module
   // since contentions will never happend
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rd_acc_data_o  <= 0;
-      rd_acc_valid_o <= 0;
+  always_comb begin
+
+    if (en_i) begin
+      rd_acc_valid_o = 1;
     end else begin
-      if (en_i) begin
-        rd_acc_data_o  <= mem[acc_addr];
-        rd_acc_valid_o <= 1;
-      end else begin
-        rd_acc_data_o  <= 0;
-        rd_acc_valid_o <= 0;
-      end
+      rd_acc_valid_o = 0;
     end
+
+    rd_acc_data_o = mem[acc_addr];
+
   end
 
   //---------------------------

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -14,8 +14,8 @@ NUM_CLASSES = 10
 
 # Working dimensions
 HV_DIM = 256
-SEED_DIM = 64
 REG_FILE_WIDTH = 32
+SEED_DIM = REG_FILE_WIDTH
 
 # Item memory parameters
 NUM_TOT_IM = 256

--- a/tests/test_inst_decode.py
+++ b/tests/test_inst_decode.py
@@ -140,6 +140,9 @@ async def inst_decode_dut(dut):
     # Initialize all other ports to 0
     dut.inst_code_i.value = 0
 
+    # Ensure that instruction decode is enabled
+    dut.enable_i.value = 1
+
     # Do this in multiple loops
     for i in range(set_parameters.TEST_RUNS):
         inst_test_list = [

--- a/tests/util.py
+++ b/tests/util.py
@@ -687,6 +687,20 @@ async def read_am_list(dut, am_start_addr, am_size):
     return am_data_list
 
 
+# Read from QHV memory
+async def read_qhv(dut, qhv_addr):
+    dut.qhv_rd_addr_i.value = qhv_addr
+
+    # Wait for one cycle
+    await clock_and_time(dut.clk_i)
+
+    # Extract data
+    qhv_data = dut.qhv_rd_data_o.value.integer
+
+    clear_tb_inputs(dut)
+    return qhv_data
+
+
 """
     Functions for CSR control
 """


### PR DESCRIPTION
This PR fixes several RTL bugs:

- [x] Add enable signal to instructions to decode to avoid sending instruction signals while disabled.
- [x] Re-wired the instruction code to the instruction decode.
- [x] Fix timing of fifos
- [x] Fix timing of the `tb_rd_memory.sv` signals
- [x] Update parameter
- [x] Add QHV read in utility