### PR TITLE
Adding low dimensional prediction

### DIFF
--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -94,7 +94,13 @@ module hypercorex_top # (
   //---------------------------
   input  logic [ HVDimension-1:0] class_hv_i,
   input  logic                    class_hv_valid_i,
-  output logic                    class_hv_ready_o
+  output logic                    class_hv_ready_o,
+  //---------------------------
+  // Low-dim prediction
+  //---------------------------
+  output logic [CsrDataWidth-1:0] predict_o,
+  output logic                    predict_valid_o,
+  input  logic                    predict_ready_i
 );
 
   //---------------------------
@@ -109,7 +115,6 @@ module hypercorex_top # (
   logic                                          clr;
   // AM settings
   logic [    CsrDataWidth-1:0]                   am_num_pred;
-  logic [    CsrDataWidth-1:0]                   am_pred;
   // Instruction control settings
   logic                                          inst_ctrl_write_mode;
   logic                                          inst_ctrl_dbg;
@@ -236,7 +241,7 @@ module hypercorex_top # (
     .csr_clr_o                  ( clr                   ),
     // AM settings
     .csr_am_num_pred_o          ( am_num_pred           ),
-    .csr_am_pred_i              ( am_pred               ),
+    .csr_am_pred_i              ( predict_o             ),
     // Instruction control settings
     .csr_inst_ctrl_write_mode_o ( inst_ctrl_write_mode  ),
     .csr_inst_ctrl_dbg_o        ( inst_ctrl_dbg         ),
@@ -479,7 +484,10 @@ module hypercorex_top # (
     .class_hv_ready_o           ( class_hv_ready_o     ),
     // CSR output side
     .am_num_class_i             ( am_num_pred          ),
-    .max_arg_idx_o              ( am_pred              )
+    // Low-dim prediction
+    .predict_o                  ( predict_o            ),
+    .predict_valid_o            ( predict_valid_o      ),
+    .predict_ready_i            ( predict_ready_i      )
   );
 
 endmodule

--- a/rtl/tb/tb_rd_memory.sv
+++ b/rtl/tb/tb_rd_memory.sv
@@ -87,17 +87,13 @@ module tb_rd_memory # (
       acc_addr <= 0;
     end else begin
       if (en_i) begin
+        // If auto loop is enabled and the end address is reached
+        // reset the counter to 0 else increment the counter
+        if (auto_loop_end && auto_loop_en_i) begin
+          acc_addr <= '0;
         // Update counter for every successful transaction
-        if (acc_success) begin
-
-          // If auto loop is enabled and the end address is reached
-          // reset the counter to 0 else increment the counter
-          if (auto_loop_end && auto_loop_en_i) begin
-            acc_addr <= '0;
-          end else begin
+        end else if (acc_success) begin
             acc_addr <= acc_addr + 1;
-          end
-
         end else begin
           acc_addr <= acc_addr;
         end

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -9,7 +9,7 @@
 import math
 
 # Test Parameters
-TEST_RUNS = 50
+TEST_RUNS = 10
 NUM_CLASSES = 10
 
 # Working dimensions

--- a/tests/util.py
+++ b/tests/util.py
@@ -537,6 +537,11 @@ def clear_tb_inputs(dut):
     # ---------------------
     dut.qhv_rd_addr_i.value = 0
 
+    # ---------------------
+    # AM predict ports
+    # ---------------------
+    dut.predict_rd_addr_i.value = 0
+
     return
 
 


### PR DESCRIPTION
This PR adds the low dimensional predict streaming port so that we can continuously stream the predicted data.

Major TODOs:
- [x] Add the low dim predict in AM
- [x] Add a test to this
- [x] Update the hypercorex top for this signal
- [x] Update the test bench for hypercorex

