### PR TITLE
Add CSR predict valid signal and control

### DIFF
--- a/rtl/assoc_memory/assoc_mem.sv
+++ b/rtl/assoc_memory/assoc_mem.sv
@@ -27,6 +27,8 @@ module assoc_mem #(
   output logic                   class_hv_ready_o,
   // CSR output side
   input  logic [  DataWidth-1:0] am_num_class_i,
+  output logic                   am_predict_valid_o,
+  input  logic                   am_predict_valid_clr_i,
   // Low-dim prediction
   output logic [  DataWidth-1:0] predict_o,
   output logic                   predict_valid_o,
@@ -178,6 +180,23 @@ module assoc_mem #(
         predict_valid_o <= 1'b0;
       end else begin
         predict_valid_o <= predict_valid_o;
+      end
+    end
+  end
+
+  //---------------------------
+  // Valid-ready control for CSR class HV
+  //---------------------------
+  always_ff @ (posedge clk_i  or negedge rst_ni) begin
+    if (!rst_ni) begin
+      am_predict_valid_o <= 1'b0;
+    end else begin
+      if (finished_predict) begin
+        am_predict_valid_o <= 1'b1;
+      end else if (am_predict_valid_clr_i) begin
+        am_predict_valid_o <= 1'b0;
+      end else begin
+        am_predict_valid_o <= am_predict_valid_o;
       end
     end
   end

--- a/rtl/csr/csr_addr_pkg.sv
+++ b/rtl/csr/csr_addr_pkg.sv
@@ -25,6 +25,8 @@ package csr_addr_pkg;
   // AM Settings
   localparam logic [31:0] AM_NUM_PREDICT_REG_ADDR         = 32'd1;
   localparam logic [31:0] AM_PREDICT_REG_ADDR             = 32'd2;
+  localparam logic [ 4:0] AM_PREDICT_BIT_ADDR             = 5'd0;
+  localparam logic [ 4:0] AM_PREDICT_VALID_BIT_ADDR       = 5'd8;
 
   // Instruction controls
   localparam logic [31:0] INST_CTRL_REG_ADDR              = 32'd3;

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -115,6 +115,8 @@ module hypercorex_top # (
   logic                                          clr;
   // AM settings
   logic [    CsrDataWidth-1:0]                   am_num_pred;
+  logic                                          am_pred_valid;
+  logic                                          am_pred_valid_clr;
   // Instruction control settings
   logic                                          inst_ctrl_write_mode;
   logic                                          inst_ctrl_dbg;
@@ -242,6 +244,8 @@ module hypercorex_top # (
     // AM settings
     .csr_am_num_pred_o          ( am_num_pred           ),
     .csr_am_pred_i              ( predict_o             ),
+    .csr_am_pred_valid_i        ( am_pred_valid         ),
+    .csr_am_pred_valid_clr_o    ( am_pred_valid_clr     ),
     // Instruction control settings
     .csr_inst_ctrl_write_mode_o ( inst_ctrl_write_mode  ),
     .csr_inst_ctrl_dbg_o        ( inst_ctrl_dbg         ),
@@ -484,6 +488,8 @@ module hypercorex_top # (
     .class_hv_ready_o           ( class_hv_ready_o     ),
     // CSR output side
     .am_num_class_i             ( am_num_pred          ),
+    .am_predict_valid_o         ( am_pred_valid        ),
+    .am_predict_valid_clr_i     ( am_pred_valid_clr    ),
     // Low-dim prediction
     .predict_o                  ( predict_o            ),
     .predict_valid_o            ( predict_valid_o      ),

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -53,6 +53,7 @@ async def read_csr(dut, addr):
 
 # Some parameters for use
 MAX_REG_VAL = (2**set_parameters.REG_FILE_WIDTH) - 1
+MAX_8B_VAL = (2**8) - 1
 
 
 @cocotb.test()
@@ -68,7 +69,8 @@ async def csr_dut(dut):
     # Initialize other signals
     # Put these to 1 for value checking
     dut.csr_busy_i.value = 1
-    dut.csr_am_pred_i.value = MAX_REG_VAL
+    dut.csr_am_pred_i.value = MAX_8B_VAL
+    dut.csr_am_pred_valid_i.value = 1
     dut.csr_inst_pc_i.value = set_parameters.INST_MEM_DEPTH - 1
     dut.csr_inst_at_addr_i.value = MAX_REG_VAL
 
@@ -150,7 +152,7 @@ async def csr_dut(dut):
     cocotb.log.info(" ------------------------------------------ ")
 
     csr_read_val = await read_csr(dut, set_parameters.AM_PREDICT_REG_ADDR)
-    check_result(csr_read_val, MAX_REG_VAL)
+    check_result(csr_read_val, (MAX_REG_VAL & 0x0000_01FF))
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("        Instruction Control Register        ")


### PR DESCRIPTION
This adds the CSR predict valid signal and control in the CSR set.

Major TODO:
- [x] Add CSR valid control inside the assoc mem
- [x] Connect to CSR set
- [x] Make sure hypercorex top is fixed
- [x] Add test in assoc mem to verify control
- [x] Add test in CSR to verify read and write capabilities