### PR TITLE
Splitting the valid-ready signal at top level

### DIFF
--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -76,13 +76,17 @@ module hypercorex_top # (
   // IM ports
   //---------------------------
   input  logic [ ImAddrWidth-1:0] lowdim_a_data_i,
+  input  logic                    lowdim_a_valid_i,
+  output logic                    lowdim_a_ready_o,
   input  logic [ HVDimension-1:0] highdim_a_data_i,
-  input  logic                    im_a_data_valid_i,
-  output logic                    im_a_data_ready_o,
+  input  logic                    highdim_a_valid_i,
+  output logic                    highdim_a_ready_o,
   input  logic [ ImAddrWidth-1:0] lowdim_b_data_i,
+  input  logic                    lowdim_b_valid_i,
+  output logic                    lowdim_b_ready_o,
   input  logic [ HVDimension-1:0] highdim_b_data_i,
-  input  logic                    im_b_data_valid_i,
-  output logic                    im_b_data_ready_o,
+  input  logic                    highdim_b_valid_i,
+  output logic                    highdim_b_ready_o,
   //---------------------------
   // QHV ports
   //---------------------------
@@ -211,6 +215,24 @@ module hypercorex_top # (
 
   assign encoder_busy = enable;
   assign busy = encoder_busy || am_busy;
+
+  //---------------------------
+  // Valid-ready Control
+  //---------------------------
+  logic im_a_data_valid;
+  logic im_b_data_valid;
+
+  logic im_a_data_ready;
+  logic im_b_data_ready;
+
+  assign im_a_data_valid   = port_a_cim[1] ? highdim_a_valid_i : lowdim_a_valid_i;
+  assign im_b_data_valid   = port_b_cim    ? highdim_b_valid_i : lowdim_b_valid_i;
+
+  assign lowdim_a_ready_o  = port_a_cim[1] ?  1'b0 : im_a_data_ready;
+  assign highdim_a_ready_o = port_a_cim[1] ? im_a_data_ready : 1'b0;
+
+  assign lowdim_b_ready_o  = port_b_cim    ?  1'b0 : im_b_data_ready;
+  assign highdim_b_ready_o = port_b_cim    ? im_b_data_ready : 1'b0;
 
   //---------------------------
   // CSR registers and control
@@ -409,12 +431,12 @@ module hypercorex_top # (
     //---------------------------
     .lowdim_a_data_i            ( lowdim_a_data_i      ),
     .highdim_a_data_i           ( highdim_a_data_i     ),
-    .im_a_data_valid_i          ( im_a_data_valid_i    ),
-    .im_a_data_ready_o          ( im_a_data_ready_o    ),
+    .im_a_data_valid_i          ( im_a_data_valid      ),
+    .im_a_data_ready_o          ( im_a_data_ready      ),
     .lowdim_b_data_i            ( lowdim_b_data_i      ),
     .highdim_b_data_i           ( highdim_b_data_i     ),
-    .im_b_data_valid_i          ( im_b_data_valid_i    ),
-    .im_b_data_ready_o          ( im_b_data_ready_o    ),
+    .im_b_data_valid_i          ( im_b_data_valid      ),
+    .im_b_data_ready_o          ( im_b_data_ready      ),
     //---------------------------
     // Outputs towards the encoder
     //---------------------------

--- a/rtl/tb/tb_hypercorex.sv
+++ b/rtl/tb/tb_hypercorex.sv
@@ -119,14 +119,20 @@ module tb_hypercorex # (
   // Wires and Logic
   //---------------------------
   logic [ ImAddrWidth-1:0] lowdim_a_data;
+  logic                    lowdim_a_valid;
+  logic                    lowdim_a_ready;
+
   logic [ HVDimension-1:0] highdim_a_data;
-  logic                    im_a_data_valid;
-  logic                    im_a_data_ready;
+  logic                    highdim_a_valid;
+  logic                    highdim_a_ready;
 
   logic [ ImAddrWidth-1:0] lowdim_b_data;
+  logic                    lowdim_b_valid;
+  logic                    lowdim_b_ready;
+
   logic [ HVDimension-1:0] highdim_b_data;
-  logic                    im_b_data_valid;
-  logic                    im_b_data_ready;
+  logic                    highdim_b_valid;
+  logic                    highdim_b_ready;
 
   logic                    qhv_ready;
   logic                    qhv_valid;
@@ -140,19 +146,7 @@ module tb_hypercorex # (
   logic                    class_hv_valid;
   logic                    class_hv_ready;
 
-  logic                    im_a_lowdim_valid;
-  logic                    im_a_highdim_valid;
-  logic                    im_a_valid;
-
-  logic                    im_b_lowdim_valid;
-  logic                    im_b_highdim_valid;
-  logic                    im_b_valid;
-
   //---------------------------
-  // Depending on Mode to Test
-  //---------------------------
-  assign im_a_data_valid = highdim_mode_i ? im_a_highdim_valid : im_a_lowdim_valid;
-  assign im_b_data_valid = highdim_mode_i ? im_b_highdim_valid : im_b_lowdim_valid;
 
   //---------------------------
   // Memory Modules
@@ -182,8 +176,8 @@ module tb_hypercorex # (
     // Accelerator access port
     .rd_acc_addr_o          (                       ),
     .rd_acc_data_o          ( lowdim_a_data         ),
-    .rd_acc_valid_o         ( im_a_lowdim_valid     ),
-    .rd_acc_ready_i         ( im_a_data_ready       )
+    .rd_acc_valid_o         ( lowdim_a_valid        ),
+    .rd_acc_ready_i         ( lowdim_a_ready        )
   );
 
   // Memory module for high dimensional memory IM B
@@ -210,8 +204,8 @@ module tb_hypercorex # (
     // Accelerator access port
     .rd_acc_addr_o          (                        ),
     .rd_acc_data_o          ( highdim_a_data         ),
-    .rd_acc_valid_o         ( im_a_highdim_valid     ),
-    .rd_acc_ready_i         ( im_a_data_ready        )
+    .rd_acc_valid_o         ( highdim_a_valid        ),
+    .rd_acc_ready_i         ( highdim_a_ready        )
   );
 
   // Memory module for low dimensional memory IM B
@@ -238,8 +232,8 @@ module tb_hypercorex # (
     // Accelerator access port
     .rd_acc_addr_o          (                       ),
     .rd_acc_data_o          ( lowdim_b_data         ),
-    .rd_acc_valid_o         ( im_b_lowdim_valid     ),
-    .rd_acc_ready_i         ( im_b_data_ready       )
+    .rd_acc_valid_o         ( lowdim_b_valid        ),
+    .rd_acc_ready_i         ( lowdim_b_ready        )
   );
 
   // Memory module for high dimensional memory IM B
@@ -266,8 +260,8 @@ module tb_hypercorex # (
     // Accelerator access port
     .rd_acc_addr_o          (                        ),
     .rd_acc_data_o          ( highdim_b_data         ),
-    .rd_acc_valid_o         ( im_b_highdim_valid     ),
-    .rd_acc_ready_i         ( im_b_data_ready        )
+    .rd_acc_valid_o         ( highdim_b_valid        ),
+    .rd_acc_ready_i         ( highdim_b_ready        )
   );
 
   // Memory module for associative memory
@@ -393,13 +387,20 @@ module tb_hypercorex # (
     // IM ports
     //---------------------------
     .lowdim_a_data_i    ( lowdim_a_data   ),
+    .lowdim_a_valid_i   ( lowdim_a_valid  ),
+    .lowdim_a_ready_o   ( lowdim_a_ready  ),
+
     .highdim_a_data_i   ( highdim_a_data  ),
-    .im_a_data_valid_i  ( im_a_data_valid ),
-    .im_a_data_ready_o  ( im_a_data_ready ),
+    .highdim_a_valid_i  ( highdim_a_valid ),
+    .highdim_a_ready_o  ( highdim_a_ready ),
+
     .lowdim_b_data_i    ( lowdim_b_data   ),
+    .lowdim_b_valid_i   ( lowdim_b_valid  ),
+    .lowdim_b_ready_o   ( lowdim_b_ready  ),
+
     .highdim_b_data_i   ( highdim_b_data  ),
-    .im_b_data_valid_i  ( im_b_data_valid ),
-    .im_b_data_ready_o  ( im_b_data_ready ),
+    .highdim_b_valid_i  ( highdim_b_valid ),
+    .highdim_b_ready_o  ( highdim_b_ready ),
     //---------------------------
     // QHV ports
     //---------------------------


### PR DESCRIPTION
This PR splits the valid-ready signal at the top level but has control within the top glue logic module.
This cleans up the ports for the SNAX cluster.

Major TODO:
- [ ] Make changes in hypercorex top
- [ ] Make changes in hypercorex testbench