### PR TITLE
Clean up to see if Questasim agrees with coding style

### DIFF
--- a/rtl/encoder/bundler_set.sv
+++ b/rtl/encoder/bundler_set.sv
@@ -45,7 +45,7 @@ module bundler_set#(
 
   always_comb begin
     for(int i = 0; i < HVDimension; i++) begin
-      binarized_hv_o[i] = (counter_o[i] >= 0) ? 1'b1 : 1'b0;
+      binarized_hv_o[i] = (counter_o[i][CounterWidth-1]) ? 1'b0 : 1'b1;
     end
   end
 

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -27,7 +27,7 @@ module hypercorex_top # (
   //---------------------------
   parameter int unsigned NumTotIm         = 1024,
   parameter int unsigned NumPerImBank     = 128,
-  parameter int unsigned ImAddrWidth      = CsrDataWidth,
+  parameter int unsigned ImAddrWidth      = $clog2(NumTotIm),
   parameter int unsigned SeedWidth        = CsrDataWidth,
   parameter int unsigned HoldFifoDepth    = 2,
   //---------------------------
@@ -407,7 +407,6 @@ module hypercorex_top # (
     .HVDimension                ( HVDimension          ),
     .NumTotIm                   ( NumTotIm             ),
     .NumPerImBank               ( NumPerImBank         ),
-    .ImAddrWidth                ( ImAddrWidth          ),
     .SeedWidth                  ( SeedWidth            ),
     .HoldFifoDepth              ( HoldFifoDepth        )
   ) i_item_memory_top (

--- a/rtl/inst_memory/inst_control.sv
+++ b/rtl/inst_memory/inst_control.sv
@@ -17,36 +17,36 @@ module inst_control # (
   parameter int unsigned InstMemAddrWidth = $clog2(InstMemDepth)
 )(
   // Clocks and reset
-  input  logic                    clk_i,
-  input  logic                    rst_ni,
+  input  logic                        clk_i,
+  input  logic                        rst_ni,
   // Control signals
-  input  logic                    clr_i,
-  input  logic                    start_i,
-  input  logic                    stall_i,
-  output logic                    enable_o,
+  input  logic                        clr_i,
+  input  logic                        start_i,
+  input  logic                        stall_i,
+  output logic                        enable_o,
   // Instruction update signals
-  input  logic                    inst_pc_reset_i,
-  input  logic                    inst_wr_mode_i,
-  input  logic [RegAddrWidth-1:0] inst_wr_addr_i,
-  input  logic                    inst_wr_addr_en_i,
-  input  logic [RegAddrWidth-1:0] inst_wr_data_i,
-  input  logic                    inst_wr_data_en_i,
-  output logic [RegAddrWidth-1:0] inst_pc_o,
-  output logic [RegAddrWidth-1:0] inst_rd_o,
+  input  logic                        inst_pc_reset_i,
+  input  logic                        inst_wr_mode_i,
+  input  logic [InstMemAddrWidth-1:0] inst_wr_addr_i,
+  input  logic                        inst_wr_addr_en_i,
+  input  logic [RegAddrWidth-1:0]     inst_wr_data_i,
+  input  logic                        inst_wr_data_en_i,
+  output logic [InstMemAddrWidth-1:0] inst_pc_o,
+  output logic [RegAddrWidth-1:0]     inst_rd_o,
   // CSR control for loop control
-  input  logic [LoopNumWidth-1:0] inst_loop_mode_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_jump_addr1_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_jump_addr2_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_jump_addr3_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_end_addr1_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_end_addr2_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_end_addr3_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_count_addr1_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_count_addr2_i,
-  input  logic [RegAddrWidth-1:0] inst_loop_count_addr3_i,
+  input  logic [LoopNumWidth-1:0]     inst_loop_mode_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_jump_addr1_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_jump_addr2_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_jump_addr3_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_end_addr1_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_end_addr2_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_end_addr3_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_count_addr1_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_count_addr2_i,
+  input  logic [InstMemAddrWidth-1:0] inst_loop_count_addr3_i,
   // Debug control signals
-  input  logic                    dbg_en_i,
-  input  logic [RegAddrWidth-1:0] dbg_addr_i
+  input  logic                        dbg_en_i,
+  input  logic [InstMemAddrWidth-1:0] dbg_addr_i
 );
 
   //---------------------------

--- a/rtl/inst_memory/inst_decode.sv
+++ b/rtl/inst_memory/inst_decode.sv
@@ -97,7 +97,6 @@ module inst_decode import hypercorex_inst_pkg::*; #(
     alu_mux_a_o     = '0;
     alu_mux_b_o     = '0;
     alu_ops_o       = '0;
-    alu_shift_amt_o = '0;
 
     // Control ports for bundlers
     bund_mux_a_o   = '0;
@@ -109,9 +108,6 @@ module inst_decode import hypercorex_inst_pkg::*; #(
 
     // Control ports for register ops
     reg_mux_o       = '0;
-    reg_rd_addr_a_o = '0;
-    reg_rd_addr_b_o = '0;
-    reg_wr_addr_o   = '0;
     reg_wr_en_o     = '0;
 
     // Control ports for query HV
@@ -134,7 +130,6 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_a_o     = '0;
         alu_mux_b_o     = '0;
         alu_ops_o       = '0;
-        alu_shift_amt_o = '0;
 
         // Control ports for bundlers
         bund_mux_a_o   = '0;
@@ -146,9 +141,6 @@ module inst_decode import hypercorex_inst_pkg::*; #(
 
         // Control ports for register ops
         reg_mux_o       = '0;
-        reg_rd_addr_a_o = '0;
-        reg_rd_addr_b_o = '0;
-        reg_wr_addr_o   = '0;
         reg_wr_en_o     = '0;
 
         // Control ports for query HV

--- a/rtl/item_memory/ca90_hier_base.sv
+++ b/rtl/item_memory/ca90_hier_base.sv
@@ -42,34 +42,38 @@ module ca90_hier_base #(
   //---------------------------
 
   ca90_unit #(
-    .Dimension   ( 32 )
+    .Dimension   ( 32               ),
+    .ShiftWidth  (  1               )
   ) i_ca90_im_0 (
     .vector_i    (        seed_hv_i ),
-    .shift_amt_i (                1 ),
+    .shift_amt_i (             1'b1 ),
     .vector_o    ( ca90_layer_out_0 )
   );
 
   ca90_unit #(
-    .Dimension   ( 64 )
+    .Dimension   ( 64               ),
+    .ShiftWidth  (  1               )
   ) i_ca90_im_1 (
     .vector_i    (  ca90_layer_in_1 ),
-    .shift_amt_i (                1 ),
+    .shift_amt_i (             1'b1 ),
     .vector_o    ( ca90_layer_out_1 )
   );
 
   ca90_unit #(
-    .Dimension   ( 128 )
+    .Dimension   ( 128              ),
+    .ShiftWidth  (  1               )
   ) i_ca90_im_2 (
     .vector_i    (  ca90_layer_in_2 ),
-    .shift_amt_i (                1 ),
+    .shift_amt_i (             1'b1 ),
     .vector_o    ( ca90_layer_out_2 )
   );
 
   ca90_unit #(
-    .Dimension   ( 256 )
+    .Dimension   ( 256              ),
+    .ShiftWidth  (  1               )
   ) i_ca90_im_3 (
     .vector_i    (  ca90_layer_in_3 ),
-    .shift_amt_i (                1 ),
+    .shift_amt_i (             1'b1 ),
     .vector_o    ( ca90_layer_out_3 )
   );
 

--- a/rtl/item_memory/ca90_item_memory.sv
+++ b/rtl/item_memory/ca90_item_memory.sv
@@ -17,14 +17,15 @@
 //---------------------------
 
 module ca90_item_memory #(
-  parameter int unsigned HVDimension   = 512,
-  parameter int unsigned NumTotIm      = 1024,
-  parameter int unsigned NumPerImBank  = 128,
-  parameter int unsigned SeedWidth     = 32,
+  parameter int unsigned HVDimension          = 512,
+  parameter int unsigned NumTotIm             = 1024,
+  parameter int unsigned NumPerImBank         = 128,
+  parameter int unsigned SeedWidth            = 32,
   // Don't touch parameters
-  parameter int unsigned Ca90ImPerm    = 7,
-  parameter int unsigned NumImSets     = NumTotIm/NumPerImBank,
-  parameter int unsigned ImSelWidth    = $clog2(NumTotIm)
+  parameter int unsigned Ca90ImPerm           = 7,
+  parameter int unsigned CA90ImPermShiftWidth = $clog2(Ca90ImPerm),
+  parameter int unsigned NumImSets            = NumTotIm/NumPerImBank,
+  parameter int unsigned ImSelWidth           = $clog2(NumTotIm)
 )(
   // Inputs
   input  logic [  NumImSets-1:0][SeedWidth-1:0] seed_hv_i,
@@ -62,11 +63,13 @@ module ca90_item_memory #(
     // Generate IM set with all other bases
     for ( j = 0; j < NumPerImBank-1; j++) begin: gen_per_im_bank
       ca90_unit #(
-        .Dimension   (               HVDimension )
+        .Dimension   (               HVDimension ),
+        // Don't touch but fixed to reduce warnings
+        .ShiftWidth  (                 CA90ImPermShiftWidth )
       ) i_ca90_im_hv (
-        .vector_i    (   item_memory_bases[i][j] ),
-        .shift_amt_i (                Ca90ImPerm ),
-        .vector_o    ( item_memory_bases[i][j+1] )
+        .vector_i    (              item_memory_bases[i][j] ),
+        .shift_amt_i ( Ca90ImPerm[CA90ImPermShiftWidth-1:0] ),
+        .vector_o    (            item_memory_bases[i][j+1] )
       );
 
     end

--- a/rtl/item_memory/item_memory.sv
+++ b/rtl/item_memory/item_memory.sv
@@ -15,16 +15,17 @@ module item_memory #(
   parameter int unsigned HVDimension = 512,
   parameter int unsigned NumTotIm    = 1024,
   parameter int unsigned NumPerImBank= 128,
-  parameter int unsigned ImAddrWidth = 32,
   parameter int unsigned SeedWidth   = 32,
   // Don't touch!
+  parameter int unsigned ImSelWidth  = $clog2(NumTotIm),
   parameter int unsigned NumImSets   = NumTotIm/NumPerImBank
+
 )(
   input  logic                                  port_a_cim_i,
   input  logic                [  SeedWidth-1:0] cim_seed_hv_i,
   input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv_i,
-  input  logic                [ImAddrWidth-1:0] im_a_addr_i,
-  input  logic                [ImAddrWidth-1:0] im_b_addr_i,
+  input  logic                [ ImSelWidth-1:0] im_a_addr_i,
+  input  logic                [ ImSelWidth-1:0] im_b_addr_i,
   output logic                [HVDimension-1:0] im_a_o,
   output logic                [HVDimension-1:0] im_b_o
 );
@@ -34,7 +35,6 @@ module item_memory #(
   //---------------------------
   localparam int unsigned NumCimLevels = HVDimension/2;
   localparam int unsigned CimSelWidth  = $clog2(NumCimLevels);
-  localparam int unsigned ImSelWidth   = $clog2(NumTotIm);
 
   //---------------------------
   // Wires

--- a/rtl/item_memory/item_memory.sv
+++ b/rtl/item_memory/item_memory.sv
@@ -17,15 +17,15 @@ module item_memory #(
   parameter int unsigned NumPerImBank= 128,
   parameter int unsigned SeedWidth   = 32,
   // Don't touch!
-  parameter int unsigned ImSelWidth  = $clog2(NumTotIm),
+  parameter int unsigned ImAddrWidth = $clog2(NumTotIm),
   parameter int unsigned NumImSets   = NumTotIm/NumPerImBank
 
 )(
   input  logic                                  port_a_cim_i,
   input  logic                [  SeedWidth-1:0] cim_seed_hv_i,
   input  logic [NumImSets-1:0][  SeedWidth-1:0] im_seed_hv_i,
-  input  logic                [ ImSelWidth-1:0] im_a_addr_i,
-  input  logic                [ ImSelWidth-1:0] im_b_addr_i,
+  input  logic                [ImAddrWidth-1:0] im_a_addr_i,
+  input  logic                [ImAddrWidth-1:0] im_b_addr_i,
   output logic                [HVDimension-1:0] im_a_o,
   output logic                [HVDimension-1:0] im_b_o
 );
@@ -48,8 +48,8 @@ module item_memory #(
   logic      [CimSelWidth-1:0] mux_cim_addr_out;
 
 
-  logic [1:0][ ImSelWidth-1:0] mux_im_addr_in;
-  logic      [ ImSelWidth-1:0] mux_im_addr_out;
+  logic [1:0][ ImAddrWidth-1:0] mux_im_addr_in;
+  logic      [ ImAddrWidth-1:0] mux_im_addr_out;
 
   //---------------------------
   // Input MUX for CiM
@@ -81,11 +81,11 @@ module item_memory #(
   //---------------------------
   // Input MUX for iM
   //---------------------------
-  assign mux_im_addr_in[0] = im_a_addr_i[ImSelWidth-1:0];
-  assign mux_im_addr_in[1] = {ImSelWidth{1'b0}};
+  assign mux_im_addr_in[0] = im_a_addr_i[ImAddrWidth-1:0];
+  assign mux_im_addr_in[1] = {ImAddrWidth{1'b0}};
 
   mux #(
-    .DataWidth  ( ImSelWidth      ),
+    .DataWidth  ( ImAddrWidth     ),
     .NumSel     ( 2               )
   ) i_mux_im_in (
     .sel_i      ( port_a_cim_i    ),

--- a/rtl/item_memory/item_memory_top.sv
+++ b/rtl/item_memory/item_memory_top.sv
@@ -13,10 +13,10 @@ module item_memory_top #(
   parameter int unsigned HVDimension   = 512,
   parameter int unsigned NumTotIm      = 1024,
   parameter int unsigned NumPerImBank  = 128,
-  parameter int unsigned ImAddrWidth   = 32,
   parameter int unsigned SeedWidth     = 32,
   parameter int unsigned HoldFifoDepth = 2,
   // Don't touch!
+  parameter int unsigned ImAddrWidth   = $clog2(NumTotIm),
   parameter int unsigned NumImSets     = NumTotIm/NumPerImBank
 )(
   // Clock and resets
@@ -90,7 +90,6 @@ module item_memory_top #(
     .HVDimension   ( HVDimension     ),
     .NumTotIm      ( NumTotIm        ),
     .NumPerImBank  ( NumPerImBank    ),
-    .ImAddrWidth   ( ImAddrWidth     ),
     .SeedWidth     ( SeedWidth       )
   ) i_item_memory (
     .port_a_cim_i  ( port_a_cim_i[0] ),

--- a/tests/test_bundler_set.py
+++ b/tests/test_bundler_set.py
@@ -13,7 +13,8 @@ from util import (
     gen_rand_bits,
     clock_and_time,
     numbip2list,
-    hvlist2num,
+    numbin2list,
+    check_result_array,
 )
 
 import cocotb
@@ -90,18 +91,13 @@ def check_binarize_out(dut, hv_bundle):
 
     # Extract actual data
     actual_val = dut.binarized_hv_o.value.integer
+    actual_val = numbin2list(actual_val, set_parameters.HV_DIM)
 
     # Convert binarized output
-    golden_val = hvlist2num(hv_binarized)
+    golden_val = hv_binarized
 
-    # Log
-    cocotb.log.info(
-        f"Binarize check! Actual output: {actual_val}; Golden output: {golden_val}"
-    )
-
-    assert (
-        golden_val == actual_val
-    ), f"Error! Actual output: {actual_val}; Golden output: {golden_val}"
+    # Check array list
+    check_result_array(actual_val, golden_val)
 
     return
 

--- a/tests/test_bundler_unit.py
+++ b/tests/test_bundler_unit.py
@@ -85,6 +85,8 @@ async def bundler_unit_dut(dut):
     # Initialize input values
     clear_inputs_no_clock(dut)
 
+    dut.rst_ni.value = 0
+
     # Initialize clock always
     clock = Clock(dut.clk_i, 10, units="ns")
     cocotb.start_soon(clock.start(start_high=False))


### PR DESCRIPTION
This PR cleans up to see if Questasim still compiles and agrees with the coding style.

Things fixed:
- [x] Bundler to use MSB to detect negative number
- [x] Bundler set test to check in arrays
- [x] Add reset signals to some tests
- [x] Take out double drivers in the instruction decode
- [x] Take out bit-width warnings from CA 90
- [x] Fix widths for item memory