### PR TITLE
Modify signals to use unpacked memories

### DIFF
--- a/rtl/common/fifo_buffer.sv
+++ b/rtl/common/fifo_buffer.sv
@@ -50,7 +50,8 @@ module fifo_buffer #(
   logic [FifoAddrWidth:0] status_cnt_n, status_cnt_q;
 
   // Main FIFO component
-  dtype [FifoDepth-1:0] mem_n, mem_q;
+  dtype mem_n [FifoDepth];
+  dtype mem_q [FifoDepth];
 
   //---------------------------
   // Some useful logic and
@@ -161,7 +162,9 @@ module fifo_buffer #(
   //---------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if(~rst_ni) begin
-      mem_q <= '0;
+      for (int i = 0; i < FifoDepth; i = i + 1) begin
+        mem_q[i] <= '0;
+      end
     end else begin
       mem_q <= mem_n;
     end

--- a/rtl/common/reg_file_1w1r.sv
+++ b/rtl/common/reg_file_1w1r.sv
@@ -32,7 +32,7 @@ module reg_file_1w1r #(
   //---------------------------
   // Wires and regs
   //---------------------------
-  logic [NumRegs-1:0][DataWidth-1:0] reg_file;
+  logic [DataWidth-1:0] reg_file [NumRegs];
 
   //---------------------------
   // Register write control

--- a/rtl/common/reg_file_1w2r.sv
+++ b/rtl/common/reg_file_1w2r.sv
@@ -35,7 +35,7 @@ module reg_file_1w2r #(
   //---------------------------
   // Wires and regs
   //---------------------------
-  logic [NumRegs-1:0][DataWidth-1:0] reg_file;
+  logic [DataWidth-1:0] reg_file [NumRegs];
 
   //---------------------------
   // Register write control

--- a/rtl/csr/csr.sv
+++ b/rtl/csr/csr.sv
@@ -91,7 +91,7 @@ module csr import csr_addr_pkg::*; #(
   //---------------------------
 
   // Register set
-  logic [NumRegs-1:0][CsrDataWidth-1:0] csr_set;
+  logic [CsrDataWidth-1:0] csr_set [NumRegs];
 
   // For CSR control
   logic csr_req_success;

--- a/rtl/item_memory/ca90_item_memory.sv
+++ b/rtl/item_memory/ca90_item_memory.sv
@@ -43,8 +43,8 @@ module ca90_item_memory #(
   //---------------------------
   // Wires
   //---------------------------
-  logic [NumTotIm-1:0][HVDimension-1:0] item_memory;
-  logic [NumImSets-1:0][NumPerImBank-1:0][HVDimension-1:0] item_memory_bases;
+  logic [HVDimension-1:0] item_memory [NumTotIm];
+  logic [HVDimension-1:0] item_memory_bases [NumImSets][NumPerImBank];
 
   //---------------------------
   // Base Item Memory

--- a/tests/util.py
+++ b/tests/util.py
@@ -84,8 +84,11 @@ def setup_and_run(
     if simulator == "verilator":
         compile_args = [
             "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
             "--no-timing",
             "--trace-structs",
+            "--unroll-count",
+            "1024",
         ]
         timescale = None
     else:


### PR DESCRIPTION
This PR modifies the memory-packed signals into unpacked elements because instead of representing memory as one long vector, it is a vector of whatever array size.

Major TODO:
- [x] Modify buffer
- [x] Modify registers
- [x] Modify item memories
- [x] Check if CI passes
- [x] Add utility Wno-UNOPT since it complains for very long logic paths.