### PR TITLE
Refactor item memory code

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -84,7 +84,6 @@ def setup_and_run(
     if simulator == "verilator":
         compile_args = [
             "-Wno-WIDTH",
-            "-Wno-UNOPTFLAT",
             "--no-timing",
             "--trace-structs",
             "--unroll-count",


### PR DESCRIPTION
This PR refactors the item memory code to avoid triggering the `Wno-UNOPT` error.
The error appears when it suspects combinational loops. The combinational loops only happen when more than 2 modules produce and consume a signal.

Major TODO:
- [x] Refactor ca90 item memory generation
- [x] Take out `Wno-UNOPT` waiver