### PR TITLE
Fix tests for item memories with a fixed seed

### DIFF
--- a/hdc_exp/char_recog.py
+++ b/hdc_exp/char_recog.py
@@ -403,8 +403,8 @@ def exp_distort_test():
 if __name__ == "__main__":
     # Some working parameters
     seed_size = 32
-    hv_dim = 256
-    num_total_im = 256
+    hv_dim = 512
+    num_total_im = 1024
     num_per_im_bank = int(hv_dim // 4)
     threshold = THRESHOLD
 
@@ -418,14 +418,28 @@ if __name__ == "__main__":
     # Prepare data indices for the accelerator
     data_indices = convert_to_data_indices(dataset)
 
+    base_seeds = [
+        1103779247,
+        2391206478,
+        3074675908,
+        2850820469,
+        811160829,
+        4032445525,
+        2525737372,
+        2535149661,
+    ]
+
     # Get a CA90 seed that's working
     seed_list, ortho_im, conf_mat = gen_ca90_im_set(
         seed_size,
         hv_dim,
         num_total_im,
         num_per_im_bank,
+        base_seeds=base_seeds,
+        gen_seed=True,
         ca90_mode="hier",
-        display_heatmap=False,
+        debug_info=True,
+        display_heatmap=True,
     )
 
     # Training of AM and extracting

--- a/hdc_exp/cim.py
+++ b/hdc_exp/cim.py
@@ -31,8 +31,18 @@ if __name__ == "__main__":
     # Set a pre-determined seed
     seed_size = 32
 
+    # Pre-calcualted custom seed
+    base_seed = 621635317
+
     # Generate the CiM
-    hv_seed, cim = gen_square_cim(HV_DIM, seed_size, im_type="ca90_hier")
+    hv_seed, cim = gen_square_cim(
+        HV_DIM,
+        seed_size,
+        base_seed=base_seed,
+        gen_seed=False,
+        im_type="ca90_hier",
+        debug_info=True,
+    )
 
     # Number of CiM levels
     cim_levels = len(cim)

--- a/hdc_exp/hdc_util.py
+++ b/hdc_exp/hdc_util.py
@@ -363,6 +363,8 @@ def gen_ca90_im_set(
     hv_dim,
     num_total_im,
     num_per_im_bank,
+    base_seeds=[0],
+    gen_seed=False,
     ca90_mode="hier",
     display_heatmap=False,
     debug_info=False,
@@ -381,7 +383,13 @@ def gen_ca90_im_set(
 
     # Extract seed list that give
     # 50% density of a base HV
-    seed_list = ca90_extract_seeds(seed_size, num_ims, hv_dim, ca90_mode=ca90_mode)
+    if gen_seed:
+        assert (
+            len(base_seeds) >= num_ims
+        ), "Error! Base seed length needs to be same as num of ims."
+        seed_list = base_seeds
+    else:
+        seed_list = ca90_extract_seeds(seed_size, num_ims, hv_dim, ca90_mode=ca90_mode)
 
     # Generate the 1st orthogonal item memory
     hv_seed = numbin2list(seed_list[0], seed_size)
@@ -412,7 +420,7 @@ def gen_ca90_im_set(
     if debug_info:
         for i in range(num_ims):
             print()  # for new line purposes
-            print(f"IM seed #{i}: {seed_list[i]}")
+            print(f"IM seed #{i}: {seed_list[i]}; hex code: {hex(seed_list[i])}")
 
     return seed_list, ortho_im, conf_mat
 
@@ -420,13 +428,18 @@ def gen_ca90_im_set(
 # Generating a square CiM
 # The number of levels is the ortho distance
 # depending on the dimension size
-def gen_square_cim(hv_dim, seed_size, im_type="random"):
-    # Set a pre-determined seed
-    lowdim_seed_list = ca90_extract_seeds(seed_size, 1, hv_dim, ca90_mode=im_type)
+def gen_square_cim(
+    hv_dim, seed_size, base_seed=0, gen_seed=True, im_type="random", debug_info=False
+):
+    if gen_seed:
+        # Set a pre-determined seed
+        lowdim_seed_list = ca90_extract_seeds(seed_size, 1, hv_dim, ca90_mode=im_type)
+        base_seed = lowdim_seed_list[0]
 
-    print(f"CiM seed: {lowdim_seed_list[0]}")
+    if debug_info:
+        print(f"CiM seed: {base_seed}")
 
-    lowdim_hv_seed = numbin2list(lowdim_seed_list[0], seed_size)
+    lowdim_hv_seed = numbin2list(base_seed, seed_size)
 
     # Half of the distance
     # which marks the number of levels

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -44,6 +44,19 @@ REG_NUM = 4
 # here, we restrict shift amount to be half of the total dimension
 MAX_SHIFT_AMT = 4
 
+# Pre-determined seeds
+BASE_SEED_CIM = 621635317
+ORTHO_IM_SEEDS = [
+    1103779247,
+    2391206478,
+    3074675908,
+    2850820469,
+    811160829,
+    4032445525,
+    2525737372,
+    2535149661,
+]
+
 # ---------------------------
 # Register addressing
 # ---------------------------

--- a/tests/test_ca90_item_memory.py
+++ b/tests/test_ca90_item_memory.py
@@ -36,6 +36,8 @@ async def ca90_item_memory_dut(dut):
         hv_dim=set_parameters.HV_DIM,
         num_total_im=set_parameters.NUM_TOT_IM,
         num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        base_seeds=set_parameters.ORTHO_IM_SEEDS,
+        gen_seed=True,
         ca90_mode=set_parameters.CA90_MODE,
     )
 

--- a/tests/test_cim.py
+++ b/tests/test_cim.py
@@ -32,6 +32,8 @@ async def cim_dut(dut):
 
     # Generated golden CiM
     seed_input, golden_cim = gen_square_cim(
+        base_seed=set_parameters.BASE_SEED_CIM,
+        gen_seed=False,
         hv_dim=set_parameters.HV_DIM,
         seed_size=set_parameters.REG_FILE_WIDTH,
         im_type="ca90_hier",

--- a/tests/test_hypercorex_char_recog.py
+++ b/tests/test_hypercorex_char_recog.py
@@ -89,6 +89,9 @@ async def tb_hypercorex_dut(dut):
         hv_dim=set_parameters.HV_DIM,
         num_total_im=set_parameters.NUM_TOT_IM,
         num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        base_seeds=set_parameters.ORTHO_IM_SEEDS,
+        gen_seed=True,
+        ca90_mode=set_parameters.CA90_MODE,
     )
 
     # Train the character recognition model

--- a/tests/test_item_memory.py
+++ b/tests/test_item_memory.py
@@ -35,6 +35,8 @@ async def item_memory_dut(dut):
 
     # Generated golden CiM
     cim_seed_input, golden_cim = gen_square_cim(
+        base_seed=set_parameters.BASE_SEED_CIM,
+        gen_seed=False,
         hv_dim=set_parameters.HV_DIM,
         seed_size=set_parameters.REG_FILE_WIDTH,
         im_type=set_parameters.CA90_MODE,
@@ -49,6 +51,8 @@ async def item_memory_dut(dut):
         hv_dim=set_parameters.HV_DIM,
         num_total_im=set_parameters.NUM_TOT_IM,
         num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        base_seeds=set_parameters.ORTHO_IM_SEEDS,
+        gen_seed=True,
         ca90_mode=set_parameters.CA90_MODE,
     )
 

--- a/tests/test_item_memory_top.py
+++ b/tests/test_item_memory_top.py
@@ -117,6 +117,8 @@ async def item_memory_top_dut(dut):
 
     # Generated golden CiM
     cim_seed_input, golden_cim = gen_square_cim(
+        base_seed=set_parameters.BASE_SEED_CIM,
+        gen_seed=False,
         hv_dim=set_parameters.HV_DIM,
         seed_size=set_parameters.REG_FILE_WIDTH,
         im_type=set_parameters.CA90_MODE,
@@ -131,6 +133,8 @@ async def item_memory_top_dut(dut):
         hv_dim=set_parameters.HV_DIM,
         num_total_im=set_parameters.NUM_TOT_IM,
         num_per_im_bank=set_parameters.NUM_PER_IM_BANK,
+        base_seeds=set_parameters.ORTHO_IM_SEEDS,
+        gen_seed=True,
         ca90_mode=set_parameters.CA90_MODE,
     )
 


### PR DESCRIPTION
This PR fixes tests for item memories with a fixed seed. 

Major TODO:
- [x] Modify `hdc_util`
- [x] Modify experiments affected
- [x] Modify tests affected