### PR TITLE
Remove seeds and make them hard fixed

### DIFF
--- a/rtl/csr/csr.sv
+++ b/rtl/csr/csr.sv
@@ -21,8 +21,8 @@ module csr import csr_addr_pkg::*; #(
   parameter int unsigned InstMemDepth     = 32,
   // Don't touch!
   parameter int unsigned NumImSets        = NumTotIm/NumPerImBank,
-  // Total number of registers + N number if IM seeds
-  parameter int unsigned NumRegs          = (14+NumImSets),
+  // Total number of registers
+  parameter int unsigned NumRegs          = 13,
   parameter int unsigned InstMemAddrWidth = $clog2(InstMemDepth),
   parameter int unsigned RegBitAddrWidth  = $clog2(CsrAddrWidth)
 )(
@@ -80,10 +80,7 @@ module csr import csr_addr_pkg::*; #(
   output logic [InstMemAddrWidth-1:0]               csr_loop_end_addr3_o,
   output logic [InstMemAddrWidth-1:0]               csr_loop_count_addr1_o,
   output logic [InstMemAddrWidth-1:0]               csr_loop_count_addr2_o,
-  output logic [InstMemAddrWidth-1:0]               csr_loop_count_addr3_o,
-  // IM Seeds
-  output logic [CsrDataWidth-1:0]                   csr_cim_seed_o,
-  output logic [   NumImSets-1:0][CsrDataWidth-1:0] csr_im_seed_o
+  output logic [InstMemAddrWidth-1:0]               csr_loop_count_addr3_o
 );
 
   //---------------------------
@@ -200,17 +197,8 @@ module csr import csr_addr_pkg::*; #(
           csr_set[csr_req_addr_i][  InstMemAddrWidth-1:                 0]  //   [7:0] RW Loop addr1
         };
       end
-      CIM_SEED_REG_ADDR: begin
-        csr_rd_data = csr_set[CIM_SEED_REG_ADDR];
-      end
       default: begin
-        // Check the variable length seed IM here
-        if((csr_req_addr_i >= IM_BASE_SEED_REG_ADDR) &&
-           (csr_req_addr_i < (IM_BASE_SEED_REG_ADDR + NumImSets))) begin
-          csr_rd_data = csr_set[csr_req_addr_i];
-        end else begin
-          csr_rd_data = {CsrDataWidth{1'b0}};
-        end
+        csr_rd_data = {CsrDataWidth{1'b0}};
       end
 
     endcase
@@ -314,13 +302,6 @@ module csr import csr_addr_pkg::*; #(
     csr_loop_count_addr2_o     = csr_set[INST_LOOP_COUNT_REG_ADDR][2*InstMemAddrWidth-1:  InstMemAddrWidth];
     csr_loop_count_addr3_o     = csr_set[INST_LOOP_COUNT_REG_ADDR][3*InstMemAddrWidth-1:2*InstMemAddrWidth];
     // verilog_lint: waive-stop line-length
-    //---------------------------
-    // IM Seeds
-    //---------------------------
-    csr_cim_seed_o             = csr_set[CIM_SEED_REG_ADDR];
-    for (int i = 0; i < NumImSets; i++) begin
-      csr_im_seed_o[i]         = csr_set[IM_BASE_SEED_REG_ADDR+i];
-    end
 
   end
 

--- a/rtl/csr/csr_addr_pkg.sv
+++ b/rtl/csr/csr_addr_pkg.sv
@@ -59,9 +59,5 @@ package csr_addr_pkg;
   localparam logic [ 4:0] INST_LOOP_COUNT_ADDR2_BIT_ADDR  = 5'd8;
   localparam logic [ 4:0] INST_LOOP_COUNT_ADDR3_BIT_ADDR  = 5'd16;
 
-  // IM seeds
-  localparam logic [31:0] CIM_SEED_REG_ADDR               = 32'd13;
-  localparam logic [31:0] IM_BASE_SEED_REG_ADDR           = 32'd14;
-
 endpackage
 // verilog_lint: waive-stop parameter-name-style

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -108,6 +108,22 @@ module hypercorex_top # (
 );
 
   //---------------------------
+  // Locally Configured Seeds
+  //---------------------------
+  logic      [SeedWidth-1:0] CiMBaseSeed;
+  logic [7:0][SeedWidth-1:0] OrthoIMSeeds;
+
+  assign CiMBaseSeed     = 32'd621635317;
+  assign OrthoIMSeeds[0] = 32'd1103779247;
+  assign OrthoIMSeeds[1] = 32'd2391206478;
+  assign OrthoIMSeeds[2] = 32'd3074675908;
+  assign OrthoIMSeeds[3] = 32'd2850820469;
+  assign OrthoIMSeeds[4] = 32'd811160829;
+  assign OrthoIMSeeds[5] = 32'd4032445525;
+  assign OrthoIMSeeds[6] = 32'd2525737372;
+  assign OrthoIMSeeds[7] = 32'd2535149661;
+
+  //---------------------------
   // CSR Control Signals
   //---------------------------
   // Core settings
@@ -142,9 +158,6 @@ module hypercorex_top # (
   logic [InstMemAddrWidth-1:0]                   loop_count_addr1;
   logic [InstMemAddrWidth-1:0]                   loop_count_addr2;
   logic [InstMemAddrWidth-1:0]                   loop_count_addr3;
-  // IM Seeds
-  logic [    CsrDataWidth-1:0]                   cim_seed;
-  logic [       NumImSets-1:0][CsrDataWidth-1:0] im_seed;
 
   //---------------------------
   // Item Memory <-> Encoder Signals
@@ -298,10 +311,7 @@ module hypercorex_top # (
     .csr_loop_end_addr3_o       ( loop_end_addr3        ),
     .csr_loop_count_addr1_o     ( loop_count_addr1      ),
     .csr_loop_count_addr2_o     ( loop_count_addr2      ),
-    .csr_loop_count_addr3_o     ( loop_count_addr3      ),
-    // IM Seeds
-    .csr_cim_seed_o             ( cim_seed              ),
-    .csr_im_seed_o              ( im_seed               )
+    .csr_loop_count_addr3_o     ( loop_count_addr3      )
   );
 
 
@@ -420,8 +430,8 @@ module hypercorex_top # (
     //---------------------------
     .port_a_cim_i               ( port_a_cim           ),
     .port_b_cim_i               ( port_b_cim           ),
-    .cim_seed_hv_i              ( cim_seed             ),
-    .im_seed_hv_i               ( im_seed              ),
+    .cim_seed_hv_i              ( CiMBaseSeed          ),
+    .im_seed_hv_i               ( OrthoIMSeeds[NumImSets-1:0] ),
     .clr_i                      ( clr                  ),
     .enable_i                   ( enable               ),
     .stall_o                    ( im_stall             ),

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -82,10 +82,6 @@ INST_LOOP_JUMP_ADDR_REG_ADDR = 10
 INST_LOOP_END_ADDR_REG_ADDR = 11
 INST_LOOP_COUNT_REG_ADDR = 12
 
-# IM seeds
-CIM_SEED_REG_ADDR = 13
-IM_BASE_SEED_REG_ADDR = 14
-
 
 # ---------------------------
 # Complete filelist

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -459,52 +459,6 @@ async def csr_dut(dut):
         ),
     )
 
-    cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("            CiM Seed Register               ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # Generate random bits to write
-    golden_val = gen_rand_bits(set_parameters.REG_FILE_WIDTH)
-
-    await write_csr(dut, golden_val, set_parameters.CIM_SEED_REG_ADDR)
-
-    # Check if value is correct
-    test_val = dut.csr_cim_seed_o.value.integer
-    check_result(test_val, golden_val)
-
-    csr_read_val = await read_csr(dut, set_parameters.CIM_SEED_REG_ADDR)
-    check_result(csr_read_val, golden_val)
-
-    cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("          CA90 iM Seed Registers            ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # Generate golden answers
-    golden_im_seed_list = []
-    num_im_seeds = int(set_parameters.NUM_TOT_IM // set_parameters.NUM_PER_IM_BANK)
-
-    for i in range(num_im_seeds):
-        # Save randomized seeds
-        im_seed = gen_rand_bits(set_parameters.REG_FILE_WIDTH)
-        golden_im_seed_list.append(im_seed)
-
-        # Write to CSR
-        await write_csr(dut, im_seed, (set_parameters.IM_BASE_SEED_REG_ADDR + i))
-
-    # Check for CSRs through reads
-    for i in range(num_im_seeds):
-        csr_read_val = await read_csr(dut, (set_parameters.IM_BASE_SEED_REG_ADDR + i))
-        check_result(csr_read_val, golden_im_seed_list[i])
-
-    # Check for the actual outputs
-    # Use masking technique here
-    for i in range(num_im_seeds):
-        test_val = dut.csr_im_seed_o.value.integer
-        check_result(
-            ((test_val >> (i * set_parameters.REG_FILE_WIDTH)) & MAX_REG_VAL),
-            golden_im_seed_list[i],
-        )
-
     # This is for waveform checking later
     for i in range(set_parameters.TEST_RUNS):
         # Propagate time for logic

--- a/tests/test_hypercorex_char_recog.py
+++ b/tests/test_hypercorex_char_recog.py
@@ -157,19 +157,6 @@ async def tb_hypercorex_dut(dut):
     dut.enable_mem_i.value = 1
 
     cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("              Write IM Seeds                ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # This writes to IM seeds
-    for i in range(set_parameters.NUM_IM_SETS):
-        await write_csr(dut, set_parameters.IM_BASE_SEED_REG_ADDR + i, im_seed_list[i])
-
-    # Next check the IM seeds
-    for i in range(set_parameters.NUM_IM_SETS):
-        read_im_seed = await read_csr(dut, set_parameters.IM_BASE_SEED_REG_ADDR + i)
-        check_result(im_seed_list[i], read_im_seed)
-
-    cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("       Write to Number of Predictions       ")
     cocotb.log.info(" ------------------------------------------ ")
 

--- a/tests/test_hypercorex_csr.py
+++ b/tests/test_hypercorex_csr.py
@@ -63,37 +63,6 @@ async def tb_hypercorex_dut(dut):
     dut.csr_rsp_ready_i.value = 1
 
     cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("         Write to CiM and IM Seeds          ")
-    cocotb.log.info(" ------------------------------------------ ")
-
-    # Generate random CIM seed
-    cim_seed = gen_rand_bits(set_parameters.REG_FILE_WIDTH)
-
-    # Generate random IM seeds
-    im_seed_list = []
-    for i in range(set_parameters.NUM_IM_SETS):
-        im_seed_list.append(gen_rand_bits(set_parameters.REG_FILE_WIDTH))
-
-    # Write seeds to the CiM and IM
-
-    # This writes to CiM seed
-    await write_csr(dut, set_parameters.CIM_SEED_REG_ADDR, cim_seed)
-
-    # This writes to IM seeds
-    for i in range(set_parameters.NUM_IM_SETS):
-        await write_csr(dut, set_parameters.IM_BASE_SEED_REG_ADDR + i, im_seed_list[i])
-
-    # Verify if the seeds are written correctly
-    # First check the CIM seed
-    read_cim_seed = await read_csr(dut, set_parameters.CIM_SEED_REG_ADDR)
-    check_result(cim_seed, read_cim_seed)
-
-    # Next check the IM seeds
-    for i in range(set_parameters.NUM_IM_SETS):
-        read_im_seed = await read_csr(dut, set_parameters.IM_BASE_SEED_REG_ADDR + i)
-        check_result(im_seed_list[i], read_im_seed)
-
-    cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("       Writing to Instruction Memory        ")
     cocotb.log.info(" ------------------------------------------ ")
 


### PR DESCRIPTION
This PR takes away the seed registers and fixes them as parameters.
This is an attempt to make sure that synthesis automatically compresses the logic.

Major TODO:
- [x] Remove CSR seeds
- [x] Remove locations from top
- [x] Modify tests for this