### PR TITLE
Add fixed CA90 unit component

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -53,6 +53,7 @@ sources:
       # ----------------------------
       # Level 0
       - rtl/item_memory/ca90_unit.sv
+      - rtl/item_memory/fixed_ca90_unit.sv
       - rtl/item_memory/cim_bit_flip.sv
       # Level 1
       - rtl/item_memory/ca90_hier_base.sv

--- a/rtl/item_memory/fixed_ca90_unit.sv
+++ b/rtl/item_memory/fixed_ca90_unit.sv
@@ -1,0 +1,46 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Fixed CA90 Item Memory Generation Unit
+// Description:
+// This is the base CA90 generation unit
+// but with fixed shifts only. This change
+// becomes necessary only because CA90 here is fixed
+//---------------------------
+
+module fixed_ca90_unit #(
+  parameter int unsigned Dimension = 512,
+  parameter int unsigned ShiftAmt  = 1
+)(
+  // Inputs
+  input  logic [ Dimension-1:0] vector_i,
+  // Outputs
+  output logic [ Dimension-1:0] vector_o
+);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic [Dimension-1:0] vector_left_shift;
+  logic [Dimension-1:0] vector_right_shift;
+
+  //---------------------------
+  // CA90 Logic
+  //---------------------------
+  always_comb begin
+    vector_left_shift  = {
+      vector_i[(Dimension-ShiftAmt)-1:0],
+      vector_i[Dimension-1:(Dimension-ShiftAmt)]
+    };
+    vector_right_shift = {
+      vector_i[ShiftAmt-1:0],
+      vector_i[Dimension-1:ShiftAmt]
+    };
+    vector_o = vector_left_shift ^ vector_right_shift;
+  end
+
+
+
+
+endmodule

--- a/tests/test_fixed_ca90_unit.py
+++ b/tests/test_fixed_ca90_unit.py
@@ -1,0 +1,95 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the basic functionality
+  of the fixed CA90 generation unit
+"""
+
+import set_parameters
+import cocotb
+from cocotb.triggers import Timer
+import pytest
+import sys
+
+from util import (
+    get_root,
+    setup_and_run,
+    gen_rand_bits,
+    gen_randint,
+    check_result,
+    numbin2list,
+    hvlist2num,
+)
+
+# Add hdc utility functions
+hdc_util_path = get_root() + "/hdc_exp/"
+sys.path.append(hdc_util_path)
+
+from hdc_util import gen_ca90  # noqa: E402
+
+# Parameters
+FIXED_SHIFT_AMT = 7
+
+
+@cocotb.test()
+async def fixed_ca90_unit_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("       Testing Fixed CA90 Generation        ")
+    cocotb.log.info("         with direct random shifts          ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # The first test checks if the CA90 is working
+    # For direct random shifts
+    for i in range(set_parameters.TEST_RUNS):
+        # Generate random input but convert
+        seed_hv = gen_rand_bits(set_parameters.HV_DIM)
+
+        # Load data into inputs
+        dut.vector_i.value = seed_hv
+
+        # Propagate time for logic
+        await Timer(1, units="ps")
+
+        # Extract output
+        actual_val = dut.vector_o.value.integer
+
+        # Calculating golden answer
+        # First convert to list
+        seed_hv = numbin2list(seed_hv, set_parameters.HV_DIM)
+
+        # Get golden answer but convert
+        # from array to binary number
+        golden_val = gen_ca90(seed_hv, FIXED_SHIFT_AMT)
+        golden_val = hvlist2num(golden_val)
+
+        # Compare outputs
+        check_result(actual_val, golden_val)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "Dimension": str(set_parameters.HV_DIM),
+            "ShiftAmt": str(FIXED_SHIFT_AMT),
+        }
+    ],
+)
+def test_fixed_ca90_unit(simulator, parameters, waves):
+    verilog_sources = ["/rtl/item_memory/fixed_ca90_unit.sv"]
+
+    toplevel = "fixed_ca90_unit"
+
+    module = "test_fixed_ca90_unit"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/test_fixed_ca90_unit.py
+++ b/tests/test_fixed_ca90_unit.py
@@ -17,7 +17,6 @@ from util import (
     get_root,
     setup_and_run,
     gen_rand_bits,
-    gen_randint,
     check_result,
     numbin2list,
     hvlist2num,


### PR DESCRIPTION
This PR adds the fixed CA90 unit component. This attempts to trick the synthesis compiler into not instantiating shifters for the CA90 unit.

Major TODO:
- [x] Add rtl for the fixed CA90 unit
- [x] Add test for the fixed CA90 unit