### PR TITLE
Add data slicer module

### DIFF
--- a/rtl/common/data_slicer.sv
+++ b/rtl/common/data_slicer.sv
@@ -74,6 +74,7 @@ module data_slicer #(
   logic [MaxCountWidth-1:0] max_chunk_count;
 
   logic chunk_count_finish;
+  logic elem_count_finish;
 
   logic [ImAddrWidth-1:0] data_slice;
   logic [7:0]             data_slice_8b [MaxCounter8b];

--- a/rtl/common/data_slicer.sv
+++ b/rtl/common/data_slicer.sv
@@ -1,0 +1,233 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Data Slicer
+// Description:
+// This module slices data very fetch
+// from the low-dim input
+//
+// This module will only support:
+// 1. 1-bit
+// 2. 4-bit
+// 3. 8-bit
+// 4. Max-bit width (64b in this case)
+//---------------------------
+
+module data_slicer #(
+  parameter int unsigned LowDimWidth     = 64,
+  parameter int unsigned NumTotIm        = 1024,
+  parameter int unsigned SlicerFifoDepth = 4,
+  parameter int unsigned CsrRegWidth     = 32,
+  // Don't touch!
+  parameter int unsigned FifoFallthrough = 1'b0,
+  parameter int unsigned ModeWidth       = 2,
+  parameter int unsigned ImAddrWidth     = $clog2(NumTotIm)
+)(
+  // Clocks and reset
+  input  logic                   clk_i,
+  input  logic                   rst_ni,
+  // Control inputs
+  input  logic                   enable_i,
+  input  logic                   clr_i,
+  input  logic [  ModeWidth-1:0] sel_mode_i,
+  // Settings
+  input  logic [CsrRegWidth-1:0] csr_elem_size_i,
+  // Data inputs
+  input  logic [LowDimWidth-1:0] lowdim_data_i,
+  input  logic                   lowdim_data_valid_i,
+  output logic                   lowdim_data_ready_o,
+  // Address outputs
+  output logic [ImAddrWidth-1:0] addr_o,
+  output logic                   addr_valid_o,
+  input  logic                   addr_ready_i
+);
+
+  //---------------------------
+  // Local parameters
+  //---------------------------
+
+  // The total number of counts
+  localparam int unsigned MaxCounter8b   = LowDimWidth / 8;
+  localparam int unsigned MaxCounter4b   = LowDimWidth / 4;
+  localparam int unsigned MaxCounter1b   = LowDimWidth / 1;
+
+  // Mode definitions
+  localparam int unsigned Mode64b        = 0;
+  localparam int unsigned Mode1b         = 1;
+  localparam int unsigned Mode4b         = 2;
+  localparam int unsigned Mode8b         = 3;
+
+  // Max counter width
+  localparam int unsigned MaxCountWidth  = $clog2(MaxCounter1b);
+
+  // Max element counter width
+  localparam int unsigned MaxElemWidth   = 32;
+
+  //---------------------------
+  // Register and Wires
+  //---------------------------
+
+  logic [MaxCountWidth-1:0] chunk_count_reg;
+  logic [ MaxElemWidth-1:0] elem_count_reg;
+
+  logic [MaxCountWidth-1:0] max_chunk_count;
+
+  logic chunk_count_finish;
+
+  logic [ImAddrWidth-1:0] data_slice;
+  logic [7:0]             data_slice_8b [MaxCounter8b];
+  logic [3:0]             data_slice_4b [MaxCounter4b];
+
+  logic fifo_out_full;
+  logic fifo_out_empty;
+
+  logic fifo_out_push;
+  logic fifo_out_pop;
+
+  // Address data + 1 bit valid
+  logic [ImAddrWidth+1-1:0] fifo_in_data;
+  logic [ImAddrWidth+1-1:0] fifo_out_data;
+
+  //---------------------------
+  // Combinational Logic
+  //---------------------------
+
+  // Element counter finish
+  assign elem_count_finish = (elem_count_reg == csr_elem_size_i-1);
+
+  // Selection for max count
+  always_comb begin
+    case (sel_mode_i)
+      Mode1b:  max_chunk_count = MaxCounter1b;
+      Mode4b:  max_chunk_count = MaxCounter4b;
+      Mode8b:  max_chunk_count = MaxCounter8b;
+      default: max_chunk_count = {MaxElemWidth{1'b0}};
+    endcase
+  end
+
+  // Chunk count finish
+  assign chunk_count_finish = (chunk_count_reg == max_chunk_count - 1);
+
+  // Re-mapping signals
+  always_comb begin
+    // Re-map for 8b cuts
+    for (int i = 0; i < MaxCounter8b; i++) begin
+      data_slice_8b[i] = lowdim_data_i[8*i +: 8];
+    end
+    // Re-map for 4b cuts
+    for (int i = 0; i < MaxCounter4b; i++) begin
+      data_slice_4b[i] = lowdim_data_i[4*i +: 4];
+    end
+  end
+
+  // Logic for data slicing in different modes other than 64b
+  always_comb begin
+    case (sel_mode_i)
+      Mode1b:  begin
+        data_slice = {{(ImAddrWidth-1){1'b0}}, lowdim_data_i[chunk_count_reg]};
+      end
+      Mode4b:  begin
+        data_slice = {{(ImAddrWidth-4){1'b0}}, data_slice_4b[chunk_count_reg[3:0]]};
+      end
+      Mode8b:  begin
+        data_slice = {{(ImAddrWidth-8){1'b0}}, data_slice_8b[chunk_count_reg[2:0]]};
+      end
+      default: begin
+        data_slice = lowdim_data_i;
+      end
+    endcase
+  end
+
+  // Logic for FIFO input
+  assign fifo_in_data = data_slice;
+
+  //---------------------------
+  // Chunk and Element Counter
+  //---------------------------
+
+  // Element counter
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      elem_count_reg  <= {MaxElemWidth{1'b0}};
+    end else begin
+      if (enable_i && (sel_mode_i != Mode64b)) begin
+        if (elem_count_finish) begin
+          elem_count_reg <= {MaxElemWidth{1'b0}};
+        end else if (fifo_out_push) begin
+          elem_count_reg <= elem_count_reg + 1;
+        end else begin
+          elem_count_reg <= elem_count_reg;
+        end
+      end else begin
+        elem_count_reg <= {MaxElemWidth{1'b0}};
+      end
+    end
+  end
+
+  // Chunk counter, note that the only difference
+  // is that chunk counter also resets after every
+  // element counter finish
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      chunk_count_reg <= {MaxCountWidth{1'b0}};
+    end else begin
+      if (enable_i && (sel_mode_i !=Mode64b )) begin
+        if (chunk_count_finish || elem_count_finish) begin
+          chunk_count_reg <= {MaxCountWidth{1'b0}};
+        end else if (fifo_out_push) begin
+          chunk_count_reg <= chunk_count_reg + 1;
+        end else begin
+          chunk_count_reg <= chunk_count_reg;
+        end
+      end else begin
+        chunk_count_reg <= {MaxCountWidth{1'b0}};
+      end
+    end
+  end
+
+  // FIFO control logic
+  assign fifo_out_push = enable_i && lowdim_data_valid_i && !fifo_out_full;
+  assign fifo_out_pop  = addr_ready_i && !fifo_out_empty;
+
+  //---------------------------
+  // Output FIFO
+  //---------------------------
+  // Output width is IM addrwidth + 1 bit valid
+  fifo_buffer #(
+    .FallThrough     ( FifoFallthrough ),
+    .DataWidth       ( ImAddrWidth     ),
+    .FifoDepth       ( SlicerFifoDepth )
+  ) i_fifo_im_a (
+    // Clocks and reset
+    .clk_i           ( clk_i           ),
+    .rst_ni          ( rst_ni          ),
+    // Software synchronous clear
+    .clr_i           ( clr_i           ),
+    // Status flags
+    .full_o          ( fifo_out_full   ),
+    .empty_o         ( fifo_out_empty  ),
+    // Note that this counter state is index 1
+    .counter_state_o ( /*Unused*/      ),
+    // Input push
+    .data_i          ( fifo_in_data    ),
+    .push_i          ( fifo_out_push   ),
+    // Output pop
+    .data_o          ( fifo_out_data   ),
+    .pop_i           ( fifo_out_pop    )
+  );
+
+  //---------------------------
+  // Output
+  //---------------------------
+  // Data in FIFO is always valid
+  // as long as it's not on an empty state
+  assign addr_o       = fifo_out_data[ImAddrWidth-1:0];
+  assign addr_valid_o = !fifo_out_empty;
+
+  // When the FIFO is not full and enable is high
+  // We can accept any requests
+  assign lowdim_data_ready_o = enable_i && !fifo_out_full;
+
+
+endmodule

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -12,15 +12,22 @@ import math
 TEST_RUNS = 10
 NUM_CLASSES = 10
 
+# Cluster parameters
+NARROW_DATA_WIDTH = 64
+
 # Working dimensions
 HV_DIM = 256
 REG_FILE_WIDTH = 32
 SEED_DIM = REG_FILE_WIDTH
 
+# Data slicer parameters
+SLICER_FIFO_DEPTH = 4
+
 # Item memory parameters
-NUM_TOT_IM = 256
+NUM_TOT_IM = 512
 NUM_PER_IM_BANK = int(HV_DIM // 4)
 NUM_IM_SETS = int(NUM_TOT_IM // NUM_PER_IM_BANK)
+IM_ADDR_WIDTH = int(math.log2(NUM_TOT_IM))
 CA90_MODE = "ca90_hier"
 IM_FIFO_DEPTH = 2
 

--- a/tests/test_data_slicer.py
+++ b/tests/test_data_slicer.py
@@ -1,0 +1,226 @@
+"""
+  Copyright 2024 KU Leuven
+  Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+  Description:
+  This tests the functionality of the data slicer
+"""
+
+from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
+
+import cocotb
+from cocotb.clock import Clock
+import pytest
+import set_parameters
+import random
+
+# Somer internal parameters
+MAX_NUM_ELEM = 100
+MIN_NUM_ELEM = 10
+
+
+# Generate random numbers
+def random_int(min_val, max_val):
+    return random.randint(min_val, max_val)
+
+
+# Set inputs to 0
+def clear_inputs_no_clock(dut):
+    dut.clr_i.value = 0
+    dut.enable_i.value = 0
+    dut.clr_i.value = 0
+    dut.sel_mode_i.value = 0
+    dut.csr_elem_size_i.value = 0
+    dut.lowdim_data_i.value = 0
+    dut.lowdim_data_valid_i.value = 0
+    dut.addr_ready_i.value = 0
+    return
+
+
+async def load_lowdim_data(dut, data):
+    dut.lowdim_data_i.value = data
+    dut.lowdim_data_valid_i.value = 1
+    await clock_and_time(dut.clk_i)
+    dut.lowdim_data_i.value = 0
+    dut.lowdim_data_valid_i.value = 0
+    return
+
+
+def load_lowdim_data_no_clk(dut, data):
+    dut.lowdim_data_i.value = data
+    dut.lowdim_data_valid_i.value = 1
+    return
+
+
+def clear_low_dim_data(dut):
+    dut.lowdim_data_i.value = 0
+    dut.lowdim_data_valid_i.value = 0
+    return
+
+
+async def clear(dut):
+    dut.clk_i.value = 1
+    await clock_and_time(dut.clk_i)
+    dut.clk_i.value = 0
+    return
+
+
+async def data_slice_test(dut, mode):
+    # Set num of slices
+    if mode == 1:
+        num_slices = 64
+        shift_factor = 1
+        mask_val = 0x1
+    elif mode == 2:
+        num_slices = 16
+        shift_factor = 4
+        mask_val = 0xF
+    elif mode == 3:
+        num_slices = 8
+        shift_factor = 8
+        mask_val = 0xFF
+    else:
+        raise ValueError("Invalid mode entry!")
+
+    # Load some starting configs
+    num_elem_test = random_int(MIN_NUM_ELEM, MAX_NUM_ELEM)
+    dut.csr_elem_size_i.value = num_elem_test
+    dut.sel_mode_i.value = mode
+
+    # Calculate how many rounds and the remainder
+    num_rounds = num_elem_test // num_slices
+    num_remainder = num_elem_test % num_slices
+
+    # Cycle through all 64b rounds
+    # Check MSB if correct
+    for i in range(num_rounds):
+        input_data = gen_rand_bits(set_parameters.NARROW_DATA_WIDTH)
+        load_lowdim_data_no_clk(dut, input_data)
+
+        # Cycle some time and check the value
+        for i in range(num_slices):
+            await clock_and_time(dut.clk_i)
+            golden_val = (input_data >> (i * shift_factor)) & mask_val
+            check_result(dut.addr_o.value.integer, golden_val)
+
+    if num_remainder != 0:
+        # Do the remainder of the data
+        input_data = gen_rand_bits(set_parameters.NARROW_DATA_WIDTH)
+        load_lowdim_data_no_clk(dut, input_data)
+        for i in range(num_remainder):
+            await clock_and_time(dut.clk_i)
+            golden_val = (input_data >> (i * shift_factor)) & mask_val
+            check_result(dut.addr_o.value.integer, golden_val)
+
+    # Clear inputs
+    clear_low_dim_data(dut)
+    return
+
+
+# Generate random data first
+def gen_rand_data_list(num_elem, datawidth):
+    rand_data_list = []
+    for i in range(num_elem):
+        rand_data_list.append(gen_rand_bits(datawidth))
+    return rand_data_list
+
+
+@cocotb.test()
+async def data_slicer_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Testing Data Slicer unit          ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize input values
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+    dut.rst_ni.value = 1
+    await clock_and_time(dut.clk_i)
+
+    # Check first that the output valid is not asserted
+    out_valid = dut.addr_valid_o.value
+    check_result(out_valid, 0)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("              Testing 64b Case              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Load some starting configs for the 64b case
+    num_elem_test = random_int(MIN_NUM_ELEM, MAX_NUM_ELEM)
+    dut.csr_elem_size_i.value = num_elem_test
+
+    dut.sel_mode_i.value = 0
+    dut.enable_i.value = 1
+    dut.addr_ready_i.value = 1
+
+    # Load random data then check immediatley
+    for i in range(num_elem_test):
+        golden_val = gen_rand_bits(set_parameters.IM_ADDR_WIDTH)
+        await load_lowdim_data(dut, golden_val)
+        output_val = dut.addr_o.value.integer
+        check_result(output_val, golden_val)
+
+    # Clear system
+    await clear(dut)
+
+    # For waveform purposes only
+    for i in range(10):
+        await clock_and_time(dut.clk_i)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("               1bit Slice Case              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    await data_slice_test(dut, 1)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("               4bit Slice Case              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    await data_slice_test(dut, 2)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("               8bit Slice Case              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    await data_slice_test(dut, 3)
+
+    # For waveform purposes only
+    for i in range(10):
+        await clock_and_time(dut.clk_i)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
+            "NumTotIm": str(set_parameters.NUM_TOT_IM),
+            "SlicerFifoDepth": str(set_parameters.SLICER_FIFO_DEPTH),
+            "CsrRegWidth": str(set_parameters.REG_FILE_WIDTH),
+        }
+    ],
+)
+def test_data_slicer(simulator, parameters, waves):
+    verilog_sources = ["/rtl/common/fifo_buffer.sv", "/rtl/common/data_slicer.sv"]
+
+    toplevel = "data_slicer"
+
+    module = "test_data_slicer"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )


### PR DESCRIPTION
This PR adds the data slicing module that is used for getting bit-wise, 4-bit wise, or 8-bit wise for every 64-bit fetch.

Major TODO:
- [x] Add RTL for data slicer
- [x] Make test for data slicer