### PR TITLE
Attach data slicer to the system

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,10 +10,13 @@ sources:
       #---------------------------
       # Common Modules
       #---------------------------
+      # Level 0
       - rtl/common/mux.sv
       - rtl/common/fifo_buffer.sv
       - rtl/common/reg_file_1w1r.sv
       - rtl/common/reg_file_1w2r.sv
+      # Level 1
+      - rtl/common/data_slicer.sv
       #---------------------------
       # Encoder
       #---------------------------

--- a/rtl/common/data_slicer.sv
+++ b/rtl/common/data_slicer.sv
@@ -18,7 +18,7 @@ module data_slicer #(
   parameter int unsigned LowDimWidth     = 64,
   parameter int unsigned NumTotIm        = 1024,
   parameter int unsigned SlicerFifoDepth = 4,
-  parameter int unsigned CsrRegWidth     = 32,
+  parameter int unsigned CsrDataWidth     = 32,
   // Don't touch!
   parameter int unsigned FifoFallthrough = 1'b0,
   parameter int unsigned ModeWidth       = 2,
@@ -32,7 +32,7 @@ module data_slicer #(
   input  logic                   clr_i,
   input  logic [  ModeWidth-1:0] sel_mode_i,
   // Settings
-  input  logic [CsrRegWidth-1:0] csr_elem_size_i,
+  input  logic [CsrDataWidth-1:0] csr_elem_size_i,
   // Data inputs
   input  logic [LowDimWidth-1:0] lowdim_data_i,
   input  logic                   lowdim_data_valid_i,
@@ -87,8 +87,8 @@ module data_slicer #(
   logic fifo_out_pop;
 
   // Address data + 1 bit valid
-  logic [ImAddrWidth+1-1:0] fifo_in_data;
-  logic [ImAddrWidth+1-1:0] fifo_out_data;
+  logic [ImAddrWidth-1:0] fifo_in_data;
+  logic [ImAddrWidth-1:0] fifo_out_data;
 
   //---------------------------
   // Combinational Logic
@@ -199,7 +199,7 @@ module data_slicer #(
     .FallThrough     ( FifoFallthrough ),
     .DataWidth       ( ImAddrWidth     ),
     .FifoDepth       ( SlicerFifoDepth )
-  ) i_fifo_im_a (
+  ) i_fifo_data_slicer (
     // Clocks and reset
     .clk_i           ( clk_i           ),
     .rst_ni          ( rst_ni          ),

--- a/rtl/encoder/hv_encoder.sv
+++ b/rtl/encoder/hv_encoder.sv
@@ -27,6 +27,8 @@ module hv_encoder #(
   // Clocks and reset
   input  logic                    clk_i,
   input  logic                    rst_ni,
+  // Global stall
+  input  logic                    global_stall_i,
   // Item memory inputs
   input  logic [ HVDimension-1:0] im_rd_a_i,
   input  logic [ HVDimension-1:0] im_rd_b_i,
@@ -77,6 +79,9 @@ module hv_encoder #(
 
   logic [HVDimension-1:0] qhv_input;
   logic [HVDimension-1:0] qhv_output;
+
+  logic                   bundle_update_a;
+  logic                   bundle_update_b;
 
   //---------------------------
   // HV register file MUX
@@ -208,6 +213,9 @@ module hv_encoder #(
     .signal_o   ( bund_input_b  )
   );
 
+  assign bundle_update_a = bund_valid_a_i && !global_stall_i;
+  assign bundle_update_b = bund_valid_b_i && !global_stall_i;
+
   //---------------------------
   // Bundler unit A
   // One can use this as spatial unit
@@ -219,7 +227,7 @@ module hv_encoder #(
     .clk_i          ( clk_i            ),
     .rst_ni         ( rst_ni           ),
     .hv_i           ( bund_input_a     ),
-    .valid_i        ( bund_valid_a_i   ),
+    .valid_i        ( bundle_update_a  ),
     .clr_i          ( bund_clr_a_i     ),
     .counter_o      (), //Unused for now
     .binarized_hv_o ( bund_output_a    )
@@ -236,7 +244,7 @@ module hv_encoder #(
     .clk_i          ( clk_i            ),
     .rst_ni         ( rst_ni           ),
     .hv_i           ( bund_input_b     ),
-    .valid_i        ( bund_valid_b_i   ),
+    .valid_i        ( bundle_update_b  ),
     .clr_i          ( bund_clr_b_i     ),
     .counter_o      (), //Unused for now
     .binarized_hv_o ( bund_output_b    )

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -570,6 +570,10 @@ module hypercorex_top # (
     .clk_i                      ( clk_i                ),
     .rst_ni                     ( rst_ni               ),
     //---------------------------
+    // Global stall
+    //---------------------------
+    .global_stall_i             ( stall                ),
+    //---------------------------
     // Item memory inputs
     //---------------------------
     .im_rd_a_i                  ( im_a                 ),

--- a/rtl/tb/tb_hypercorex.sv
+++ b/rtl/tb/tb_hypercorex.sv
@@ -27,6 +27,7 @@ module tb_hypercorex # (
   parameter int unsigned ImAddrWidth      = CsrDataWidth,
   parameter int unsigned SeedWidth        = CsrDataWidth,
   parameter int unsigned HoldFifoDepth    = 2,
+  parameter bit          EnableRomIM      = 1'b0,
   //---------------------------
   // Instruction Memory Parameters
   //---------------------------
@@ -359,6 +360,7 @@ module tb_hypercorex # (
     .NumPerImBank       ( NumPerImBank     ),
     .ImAddrWidth        ( ImAddrWidth      ),
     .SeedWidth          ( SeedWidth        ),
+    .EnableRomIM        ( EnableRomIM      ),
     .HoldFifoDepth      ( HoldFifoDepth    ),
     .InstMemDepth       ( InstMemDepth     ),
     .BundCountWidth     ( BundCountWidth   ),

--- a/rtl/tb/tb_hypercorex.sv
+++ b/rtl/tb/tb_hypercorex.sv
@@ -13,6 +13,7 @@ module tb_hypercorex # (
   // General Parameters
   //---------------------------
   parameter int unsigned HVDimension      = 512,
+  parameter int unsigned LowDimWidth      = 64,
   //---------------------------
   // CSR Parameters
   //---------------------------
@@ -119,7 +120,7 @@ module tb_hypercorex # (
   //---------------------------
   // Wires and Logic
   //---------------------------
-  logic [ ImAddrWidth-1:0] lowdim_a_data;
+  logic [ LowDimWidth-1:0] lowdim_a_data;
   logic                    lowdim_a_valid;
   logic                    lowdim_a_ready;
 
@@ -127,7 +128,7 @@ module tb_hypercorex # (
   logic                    highdim_a_valid;
   logic                    highdim_a_ready;
 
-  logic [ ImAddrWidth-1:0] lowdim_b_data;
+  logic [ LowDimWidth-1:0] lowdim_b_data;
   logic                    lowdim_b_valid;
   logic                    lowdim_b_ready;
 

--- a/tests/set_parameters.py
+++ b/tests/set_parameters.py
@@ -8,6 +8,9 @@
 
 import math
 
+# Enable ROM IM
+ENABLE_ROM_IM = 0
+
 # Test Parameters
 TEST_RUNS = 10
 NUM_CLASSES = 10
@@ -16,7 +19,10 @@ NUM_CLASSES = 10
 NARROW_DATA_WIDTH = 64
 
 # Working dimensions
-HV_DIM = 256
+if ENABLE_ROM_IM:
+    HV_DIM = 512
+else:
+    HV_DIM = 256
 REG_FILE_WIDTH = 32
 SEED_DIM = REG_FILE_WIDTH
 
@@ -24,7 +30,10 @@ SEED_DIM = REG_FILE_WIDTH
 SLICER_FIFO_DEPTH = 4
 
 # Item memory parameters
-NUM_TOT_IM = 512
+if ENABLE_ROM_IM:
+    NUM_TOT_IM = 1024
+else:
+    NUM_TOT_IM = 512
 NUM_PER_IM_BANK = int(HV_DIM // 4)
 NUM_IM_SETS = int(NUM_TOT_IM // NUM_PER_IM_BANK)
 IM_ADDR_WIDTH = int(math.log2(NUM_TOT_IM))

--- a/tests/test_data_slicer.py
+++ b/tests/test_data_slicer.py
@@ -205,7 +205,7 @@ async def data_slicer_dut(dut):
             "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
             "NumTotIm": str(set_parameters.NUM_TOT_IM),
             "SlicerFifoDepth": str(set_parameters.SLICER_FIFO_DEPTH),
-            "CsrRegWidth": str(set_parameters.REG_FILE_WIDTH),
+            "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
         }
     ],
 )

--- a/tests/test_hypercorex_char_recog.py
+++ b/tests/test_hypercorex_char_recog.py
@@ -294,6 +294,8 @@ async def tb_hypercorex_dut(dut):
     "parameters",
     [
         {
+            # Enable ROM IM
+            "EnableRomIM": str(set_parameters.ENABLE_ROM_IM),
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
             "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
@@ -322,7 +324,6 @@ async def tb_hypercorex_dut(dut):
 def test_hypercorex_char_recog(simulator, parameters, waves):
     bender_path = bender_path = get_dir() + "/../."
     bender_filelist = get_bender_filelist(bender_path)
-    print(bender_filelist)
     verilog_sources = bender_filelist
     toplevel = "tb_hypercorex"
 

--- a/tests/test_hypercorex_char_recog.py
+++ b/tests/test_hypercorex_char_recog.py
@@ -296,6 +296,7 @@ async def tb_hypercorex_dut(dut):
         {
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
+            "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
             # CSR parameters
             "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
             "CsrAddrWidth": str(set_parameters.REG_FILE_WIDTH),

--- a/tests/test_hypercorex_csr.py
+++ b/tests/test_hypercorex_csr.py
@@ -160,6 +160,7 @@ async def tb_hypercorex_dut(dut):
         {
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
+            "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
             # CSR parameters
             "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
             "CsrAddrWidth": str(set_parameters.REG_FILE_WIDTH),

--- a/tests/test_hypercorex_csr.py
+++ b/tests/test_hypercorex_csr.py
@@ -148,6 +148,10 @@ async def tb_hypercorex_dut(dut):
     # Mask only the lower 3*INST_MEM_ADDR_WIDTH bits
     check_result((golden_val & mask), read_val)
 
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("     Writing to Loop Control Registers      ")
+    cocotb.log.info(" ------------------------------------------ ")
+
     # Some trailing cycles only
     for i in range(10):
         await clock_and_time(dut.clk_i)
@@ -158,6 +162,8 @@ async def tb_hypercorex_dut(dut):
     "parameters",
     [
         {
+            # Enable ROM IM
+            "EnableRomIM": str(set_parameters.ENABLE_ROM_IM),
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
             "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),

--- a/tests/test_tb_hypercorex.py
+++ b/tests/test_tb_hypercorex.py
@@ -122,6 +122,7 @@ async def tb_hypercorex_dut(dut):
         {
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
+            "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),
             # CSR parameters
             "CsrDataWidth": str(set_parameters.REG_FILE_WIDTH),
             "CsrAddrWidth": str(set_parameters.REG_FILE_WIDTH),

--- a/tests/test_tb_hypercorex.py
+++ b/tests/test_tb_hypercorex.py
@@ -120,6 +120,8 @@ async def tb_hypercorex_dut(dut):
     "parameters",
     [
         {
+            # Enable ROM IM
+            "EnableRomIM": str(set_parameters.ENABLE_ROM_IM),
             # General parameters
             "HVDimension": str(set_parameters.HV_DIM),
             "LowDimWidth": str(set_parameters.NARROW_DATA_WIDTH),


### PR DESCRIPTION
This PR is an initial move to attach the data slicer as part of the system.
The first major test is to see if the data slicer works for the main 64b data chunks sent to the system.

Major TODO:
- [x] Attach data slicer
- [x] Make sure existing tests work

Bug fix:
- [x] There was a timing issue where the bundler was auto-incrementing even though the IM had not loaded any data yet. This was fixed by inserting the stall with the bundler update signal. When a stall occurs, the bundler or any write update signals should not run.

