### PR TITLE
Add left shift functionality

### DIFF
--- a/rtl/encoder/hv_alu_pe.sv
+++ b/rtl/encoder/hv_alu_pe.sv
@@ -9,7 +9,7 @@
 //---------------------------
 module hv_alu_pe #(
   parameter int unsigned HVDimension   = 512,
-  parameter int unsigned NumOps        = 4,
+  parameter int unsigned NumOps        = 8,
   parameter int unsigned NumOpsWidth   = $clog2(NumOps),
   parameter int unsigned MaxShiftAmt   = 4,
   parameter int unsigned ShiftWidth    = $clog2(MaxShiftAmt)
@@ -33,16 +33,29 @@ module hv_alu_pe #(
   // 2: 8 shift
   // 3: 16 shift
   //---------------------------
-  logic [HVDimension-1:0] circular_shift_res;
+  logic [HVDimension-1:0] circular_shift_right;
+  logic [HVDimension-1:0] circular_shift_left;
 
   // Doing selections through wire slicing
   // rather than actual shifts to optimize synthesis
+
+  // Shift right
   always_comb begin
     case (shift_amt_i)
-      default: circular_shift_res = {A_i[   0], A_i[ HVDimension-1:1]};
-            1: circular_shift_res = {A_i[ 3:0], A_i[ HVDimension-1:4]};
-            2: circular_shift_res = {A_i[ 7:0], A_i[ HVDimension-1:8]};
-            3: circular_shift_res = {A_i[15:0], A_i[HVDimension-1:16]};
+      default: circular_shift_right = {A_i[   0], A_i[ HVDimension-1:1]};
+            1: circular_shift_right = {A_i[ 3:0], A_i[ HVDimension-1:4]};
+            2: circular_shift_right = {A_i[ 7:0], A_i[ HVDimension-1:8]};
+            3: circular_shift_right = {A_i[15:0], A_i[HVDimension-1:16]};
+    endcase
+  end
+
+  // Shift left
+  always_comb begin
+    case (shift_amt_i)
+      default: circular_shift_left = {A_i[HVDimension-2:0],  A_i[HVDimension-1]};
+            1: circular_shift_left = {A_i[HVDimension-5:0],  A_i[HVDimension-1:HVDimension-4]};
+            2: circular_shift_left = {A_i[HVDimension-9:0],  A_i[HVDimension-1:HVDimension-8]};
+            3: circular_shift_left = {A_i[HVDimension-17:0], A_i[HVDimension-1:HVDimension-16]};
     endcase
   end
 
@@ -56,9 +69,10 @@ module hv_alu_pe #(
   //---------------------------
   always_comb begin : alu_logic
     case (op_i)
-      2'b01:   C_o = A_i;
-      2'b10:   C_o = B_i;
-      2'b11:   C_o = circular_shift_res;
+      3'b001:  C_o = A_i;
+      3'b010:  C_o = B_i;
+      3'b011:  C_o = circular_shift_right;
+      3'b100:  C_o = circular_shift_left;
       default: C_o = A_i ^ B_i;
     endcase
   end

--- a/rtl/encoder/hv_encoder.sv
+++ b/rtl/encoder/hv_encoder.sv
@@ -19,7 +19,7 @@ module hv_encoder #(
   parameter int unsigned QvMuxWidth     = 2,
   parameter int unsigned RegNum         = 4,
   // Don't touch!
-  parameter int unsigned NumALUOps      = 4,
+  parameter int unsigned NumALUOps      = 8,
   parameter int unsigned ALUOpsWidth    = $clog2(NumALUOps     ),
   parameter int unsigned ShiftWidth     = $clog2(ALUMaxShiftAmt),
   parameter int unsigned RegAddrWidth   = $clog2(RegNum        )

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -56,7 +56,7 @@ module hypercorex_top # (
   //---------------------------
   parameter int unsigned SlicerModeWidth  = 2,
   parameter int unsigned SrcSelWidth      = 2,
-  parameter int unsigned NumALUOps        = 4,
+  parameter int unsigned NumALUOps        = 8,
   parameter int unsigned ObservableWidth  = 4,
   parameter int unsigned ALUOpsWidth      = $clog2(NumALUOps     ),
   parameter int unsigned ShiftWidth       = $clog2(ALUMaxShiftAmt),
@@ -643,7 +643,8 @@ module hypercorex_top # (
     .ALUMaxShiftAmt             ( ALUMaxShiftAmt       ),
     .RegMuxWidth                ( RegMuxWidth          ),
     .QvMuxWidth                 ( QvMuxWidth           ),
-    .RegNum                     ( RegNum               )
+    .RegNum                     ( RegNum               ),
+    .NumALUOps                  ( NumALUOps            )
   ) i_hv_encoder (
     //---------------------------
     // Clocks and reset

--- a/rtl/inst_memory/inst_decode.sv
+++ b/rtl/inst_memory/inst_decode.sv
@@ -27,7 +27,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
   parameter int unsigned QvMuxWidth     = 2,
   parameter int unsigned RegNum         = 4,
   // Don't touch!
-  parameter int unsigned NumALUOps      = 4,
+  parameter int unsigned NumALUOps      = 8,
   parameter int unsigned ALUOpsWidth    = $clog2(NumALUOps     ),
   parameter int unsigned ShiftWidth     = $clog2(ALUMaxShiftAmt),
   parameter int unsigned RegAddrWidth   = $clog2(RegNum        )
@@ -160,14 +160,14 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_a_o = 2'b00;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b01;
+        alu_ops_o   = 3'b001;
       end
       IMB_REG: begin
         im_b_pop_o  = 1'b1;
         alu_mux_b_o = 2'b00;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b10;
+        alu_ops_o   = 3'b010;
       end
       IMAB_BIND_REG: begin
         im_a_pop_o  = 1'b1;
@@ -176,14 +176,14 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o = 2'b00;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       IMA_PERM_REG: begin
         im_a_pop_o  = 1'b1;
         alu_mux_a_o = 2'b00;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b11;
+        alu_ops_o   = 3'b011;
       end
       //---------------------------
       // IM-REG
@@ -194,7 +194,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o = 2'b01;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       IMB_REGA_BIND_REG: begin
         im_b_pop_o  = 1'b1;
@@ -202,7 +202,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o = 2'b00;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       //---------------------------
       // IM-BUND
@@ -224,7 +224,7 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o    = 2'b00;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       IMAB_BIND_BUNDB: begin
         im_a_pop_o     = 1'b1;
@@ -233,21 +233,21 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o    = 2'b00;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 2'b00;
+        alu_ops_o      = 3'b000;
       end
       IMA_PERM_BUNDA: begin
         im_a_pop_o     = 1'b1;
         alu_mux_a_o    = 2'b00;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 2'b11;
+        alu_ops_o      = 3'b000;
       end
       IMA_PERM_BUNDB: begin
         im_a_pop_o     = 1'b1;
         alu_mux_a_o    = 2'b00;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 2'b11;
+        alu_ops_o      = 3'b000;
       end
       //---------------------------
       // REG
@@ -257,19 +257,19 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o = 2'b01;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       REGA_PERM_REG: begin
         alu_mux_a_o = 2'b01;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b11;
+        alu_ops_o   = 3'b011;
       end
       MV_REG: begin
         alu_mux_a_o = 2'b01;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b01;
+        alu_ops_o   = 3'b001;
       end
       //---------------------------
       // REG-BUND
@@ -279,52 +279,52 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_b_o    = 2'b01;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 2'b00;
+        alu_ops_o      = 3'b000;
       end
       REGAB_BIND_BUNDB: begin
         alu_mux_a_o    = 2'b01;
         alu_mux_b_o    = 2'b01;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 2'b00;
+        alu_ops_o      = 3'b000;
       end
       REGA_PERM_BUNDA: begin
         alu_mux_a_o    = 2'b01;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 2'b11;
+        alu_ops_o      = 3'b000;
       end
       REGA_PERM_BUNDB: begin
         alu_mux_a_o    = 2'b01;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 2'b11;
+        alu_ops_o      = 3'b000;
       end
       REGA_BUNDA_BIND_REG: begin
         alu_mux_a_o = 2'b01;
         alu_mux_b_o = 2'b10;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       REGA_BUNDB_BIND_REG: begin
         alu_mux_a_o = 2'b01;
         alu_mux_b_o = 2'b11;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b00;
+        alu_ops_o   = 3'b000;
       end
       BUNDA_PERM_REG: begin
         alu_mux_a_o = 2'b10;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b11;
+        alu_ops_o   = 3'b011;
       end
       BUNDB_PERM_REG: begin
         alu_mux_a_o = 2'b11;
         reg_mux_o   = 2'b00;
         reg_wr_en_o = 1'b1;
-        alu_ops_o   = 2'b11;
+        alu_ops_o   = 3'b011;
       end
       MV_BUNDA_REG: begin
         reg_mux_o   = 2'b10;

--- a/rtl/inst_memory/inst_decode.sv
+++ b/rtl/inst_memory/inst_decode.sv
@@ -240,14 +240,14 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_a_o    = 2'b00;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 3'b000;
+        alu_ops_o      = 3'b011;
       end
       IMA_PERM_BUNDB: begin
         im_a_pop_o     = 1'b1;
         alu_mux_a_o    = 2'b00;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 3'b000;
+        alu_ops_o      = 3'b011;
       end
       //---------------------------
       // REG
@@ -292,13 +292,13 @@ module inst_decode import hypercorex_inst_pkg::*; #(
         alu_mux_a_o    = 2'b01;
         bund_mux_a_o   = 2'b00;
         bund_valid_a_o = 1'b1;
-        alu_ops_o      = 3'b000;
+        alu_ops_o      = 3'b011;
       end
       REGA_PERM_BUNDB: begin
         alu_mux_a_o    = 2'b01;
         bund_mux_b_o   = 2'b00;
         bund_valid_b_o = 1'b1;
-        alu_ops_o      = 3'b000;
+        alu_ops_o      = 3'b011;
       end
       REGA_BUNDA_BIND_REG: begin
         alu_mux_a_o = 2'b01;

--- a/sw/hypercorex_compiler.py
+++ b/sw/hypercorex_compiler.py
@@ -81,7 +81,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
     # Control ports for ALU
     alu_mux_a = [0, 0]
     alu_mux_b = [0, 0]
-    alu_ops = [0, 0]
+    alu_ops = [0, 0, 0]
     alu_shift_amt = [0, 0]
 
     # Control ports for bundlers
@@ -120,7 +120,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 1]
+        alu_ops = [0, 0, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
     elif asm_inst == "imb_reg":
         inst_type = num2list(0, TYPE_LEN)
@@ -129,7 +129,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [1, 0]
+        alu_ops = [0, 1, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
     elif asm_inst == "imab_bind_reg":
         inst_type = num2list(0, TYPE_LEN)
@@ -140,7 +140,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
     elif asm_inst == "ima_perm_reg":
         inst_type = num2list(0, TYPE_LEN)
@@ -149,7 +149,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
         alu_shift_amt = num2list(asm_line[2], 2)
     # IM-REG
@@ -161,7 +161,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_b = num2list(asm_line[2], 2)
     elif asm_inst == "imb_rega_bind_reg":
@@ -172,7 +172,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
     # IM-BUND
@@ -197,7 +197,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 0]
         bund_mux_a = [0, 0]
         bund_valid_a = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
     elif asm_inst == "imab_bind_bundb":
         inst_type = num2list(2, TYPE_LEN)
         func_type = num2list(4, FUNC_LEN)
@@ -207,7 +207,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 0]
         bund_mux_b = [0, 0]
         bund_valid_b = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
     elif asm_inst == "ima_perm_bunda":
         inst_type = num2list(2, TYPE_LEN)
         func_type = num2list(5, FUNC_LEN)
@@ -215,7 +215,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 0]
         bund_mux_a = [0, 0]
         bund_valid_a = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         alu_shift_amt = num2list(asm_line[1], 2)
     elif asm_inst == "ima_perm_bundb":
         inst_type = num2list(2, TYPE_LEN)
@@ -224,7 +224,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 0]
         bund_mux_b = [0, 0]
         bund_valid_b = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         alu_shift_amt = num2list(asm_line[1], 2)
     # REG
     elif asm_inst == "regab_bind_reg":
@@ -234,7 +234,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
         reg_rd_addr_b = num2list(asm_line[3], 2)
@@ -244,7 +244,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
         alu_shift_amt = num2list(asm_line[3], 2)
@@ -254,7 +254,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 1]
+        alu_ops = [0, 0, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
     # REG-BUND
@@ -265,7 +265,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 1]
         bund_mux_a = [0, 0]
         bund_valid_a = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_rd_addr_a = num2list(asm_line[1], 2)
         reg_rd_addr_b = num2list(asm_line[2], 2)
     elif asm_inst == "regab_bind_bundb":
@@ -275,7 +275,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [0, 1]
         bund_mux_b = [0, 0]
         bund_valid_b = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_rd_addr_a = num2list(asm_line[1], 2)
         reg_rd_addr_b = num2list(asm_line[2], 2)
     elif asm_inst == "rega_perm_bunda":
@@ -284,7 +284,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 1]
         bund_mux_a = [0, 0]
         bund_valid_a = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_rd_addr_a = num2list(asm_line[1], 2)
         alu_shift_amt = num2list(asm_line[2], 2)
     elif asm_inst == "rega_perm_bundb":
@@ -293,7 +293,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [0, 1]
         bund_mux_b = [0, 0]
         bund_valid_b = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_rd_addr_a = num2list(asm_line[1], 2)
         alu_shift_amt = num2list(asm_line[2], 2)
     elif asm_inst == "rega_bunda_bind_reg":
@@ -303,7 +303,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [1, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
     elif asm_inst == "rega_bundb_bind_reg":
@@ -313,7 +313,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_b = [1, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [0, 0]
+        alu_ops = [0, 0, 0]
         reg_wr_addr = num2list(asm_line[1], 2)
         reg_rd_addr_a = num2list(asm_line[2], 2)
     elif asm_inst == "bunda_perm_reg":
@@ -322,7 +322,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [1, 0]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
         alu_shift_amt = num2list(asm_line[2], 2)
     elif asm_inst == "bundb_perm_reg":
@@ -331,7 +331,7 @@ def decode_inst(asm_line, sanity_check=False, convert_str=False, print_ctrl=Fals
         alu_mux_a = [1, 1]
         reg_mux = [0, 0]
         reg_wr_en = [1]
-        alu_ops = [1, 1]
+        alu_ops = [0, 1, 1]
         reg_wr_addr = num2list(asm_line[1], 2)
         alu_shift_amt = num2list(asm_line[2], 2)
     elif asm_inst == "mv_bunda_reg":

--- a/tests/test_hv_alu_pe.py
+++ b/tests/test_hv_alu_pe.py
@@ -18,7 +18,7 @@ import pytest
 # Routinary test
 async def gen_and_test(dut, hv_dim, shift_amt, mode):
     # Generate data
-    if mode == 3:
+    if mode == 3 or mode == 4:
         A = gen_rand_bits(set_parameters.HV_DIM)
         B = 0
         shift_amt = gen_randint(shift_amt)
@@ -83,14 +83,24 @@ async def hv_alu_pe_dut(dut):
     for i in range(set_parameters.TEST_RUNS):
         await gen_and_test(dut, set_parameters.HV_DIM, 0, 2)
 
-    cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("       Testing Circular Shift Cases         ")
-    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info(" ------------------------------------------------ ")
+    cocotb.log.info("       Testing Circular Right Shift Cases         ")
+    cocotb.log.info(" ------------------------------------------------ ")
 
     # Test circular shift cases
     for i in range(set_parameters.TEST_RUNS):
         await gen_and_test(
             dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT - 1, 3
+        )
+
+    cocotb.log.info(" ------------------------------------------------ ")
+    cocotb.log.info("        Testing Circular Left Shift Cases         ")
+    cocotb.log.info(" ------------------------------------------------ ")
+
+    # Test circular shift cases
+    for i in range(set_parameters.TEST_RUNS):
+        await gen_and_test(
+            dut, set_parameters.HV_DIM, set_parameters.MAX_SHIFT_AMT - 1, 4
         )
 
 

--- a/tests/test_inst_decode.py
+++ b/tests/test_inst_decode.py
@@ -260,7 +260,7 @@ async def inst_decode_dut(dut):
         }
     ],
 )
-def test_item_memory(simulator, parameters, waves):
+def test_inst_decode(simulator, parameters, waves):
     verilog_sources = [
         "/rtl/inst_memory/hypercorex_inst_pkg.sv",
         "/rtl/inst_memory/inst_decode.sv",

--- a/tests/util.py
+++ b/tests/util.py
@@ -202,14 +202,8 @@ def hv_alu_out(hv_a, hv_b, shift_amt, hv_dim, op):
         result = hv_a
     elif op == 2:
         result = hv_b
-    elif op == 3:
-        # Workaround because github CI fails
-        # At shifting more than 64 bits
-        # if isinstance(hv_a, np.ndarray):
-        #     result = np.roll(hv_a, shift_amt)
-        # else:
-        #     result = (hv_a >> shift_amt) | (hv_a << (hv_dim - shift_amt)) & mask_val
-        result = shift_hv(hv_a, shift_amt, hv_dim)
+    elif op == 3 or op == 4:
+        result = shift_hv(hv_a, shift_amt, hv_dim, op)
     else:
         result = hv_a ^ hv_b
     return result
@@ -247,17 +241,29 @@ def hvlist2num(hv_list):
 
 
 # Shift modes based on shift values
-def shift_hv(hv_a, shift_amt, hv_dim):
+def shift_hv(hv_a, shift_amt, hv_dim, op):
     mask_val = 2**hv_dim - 1
 
     if shift_amt == 0:
-        result = (hv_a >> 1) | (hv_a << (hv_dim - 1)) & mask_val
+        if op == 3:
+            result = (hv_a >> 1) | (hv_a << (hv_dim - 1)) & mask_val
+        else:
+            result = ((hv_a << 1) | (hv_a >> (hv_dim - 1))) & mask_val
     elif shift_amt == 1:
-        result = (hv_a >> 4) | (hv_a << (hv_dim - 4)) & mask_val
+        if op == 3:
+            result = (hv_a >> 4) | (hv_a << (hv_dim - 4)) & mask_val
+        else:
+            result = ((hv_a << 4) | (hv_a >> (hv_dim - 4))) & mask_val
     elif shift_amt == 2:
-        result = (hv_a >> 8) | (hv_a << (hv_dim - 8)) & mask_val
+        if op == 3:
+            result = (hv_a >> 8) | (hv_a << (hv_dim - 8)) & mask_val
+        else:
+            result = ((hv_a << 8) | (hv_a >> (hv_dim - 8))) & mask_val
     else:
-        result = (hv_a >> 16) | (hv_a << (hv_dim - 16)) & mask_val
+        if op == 3:
+            result = (hv_a >> 16) | (hv_a << (hv_dim - 16)) & mask_val
+        else:
+            result = ((hv_a << 16) | (hv_a >> (hv_dim - 16))) & mask_val
 
     return result
 


### PR DESCRIPTION
This PR adds the left-shift functionality to the HV ALU PE.

Major TODO:
- [x] Modify HV ALU
- [x] Port the signals up to the top
- [x] Don't forget the instruction decode
- [x] Modify HV alu test