### PR TITLE
Separate data slice mode in CSR

### DIFF
--- a/rtl/csr/csr.sv
+++ b/rtl/csr/csr.sv
@@ -93,7 +93,8 @@ module csr import csr_addr_pkg::*; #(
   output logic [    CsrDataWidth-1:0]               csr_auto_count_num_a_o,
   output logic [    CsrDataWidth-1:0]               csr_auto_count_num_b_o,
   // Data slicer configurations
-  output logic [ SlicerModeWidth-1:0]               csr_data_slice_mode_o,
+  output logic [ SlicerModeWidth-1:0]               csr_data_slice_mode_a_o,
+  output logic [ SlicerModeWidth-1:0]               csr_data_slice_mode_b_o,
   output logic [    CsrDataWidth-1:0]               csr_data_slice_num_elem_a_o,
   output logic [    CsrDataWidth-1:0]               csr_data_slice_num_elem_b_o,
   // Data source control
@@ -224,8 +225,9 @@ module csr import csr_addr_pkg::*; #(
       DATA_SRC_CTRL_REG_ADDR: begin
         csr_rd_data = {
           {(CsrDataWidth-2){1'b0}},             // [31:2] -- Unused
-          csr_set[DATA_SRC_CTRL_REG_ADDR][3:2], // [3:2] RW source select
-          csr_set[DATA_SRC_CTRL_REG_ADDR][1:0]  // [1:0] RW Data slice mode
+          csr_set[DATA_SRC_CTRL_REG_ADDR][5:4], // [5:4] RW source select for a and b
+          csr_set[DATA_SRC_CTRL_REG_ADDR][3:2], // [3:2] RW Data slice mode for b
+          csr_set[DATA_SRC_CTRL_REG_ADDR][1:0]  // [1:0] RW Data slice mode for a
         };
       end
       DATA_SLICE_NUM_ELEM_A_REG_ADDR,
@@ -369,14 +371,15 @@ module csr import csr_addr_pkg::*; #(
     //---------------------------
     // Data slicer configurations
     //---------------------------
-    csr_data_slice_mode_o       = csr_set[DATA_SRC_CTRL_REG_ADDR][1:0];
+    csr_data_slice_mode_a_o     = csr_set[DATA_SRC_CTRL_REG_ADDR][1:0];
+    csr_data_slice_mode_b_o     = csr_set[DATA_SRC_CTRL_REG_ADDR][3:2];
     csr_data_slice_num_elem_a_o = csr_set[DATA_SLICE_NUM_ELEM_A_REG_ADDR];
     csr_data_slice_num_elem_b_o = csr_set[DATA_SLICE_NUM_ELEM_B_REG_ADDR];
 
     //---------------------------
     // Data source control
     //---------------------------
-    csr_data_src_sel_o          = csr_set[DATA_SRC_CTRL_REG_ADDR][3:2];
+    csr_data_src_sel_o          = csr_set[DATA_SRC_CTRL_REG_ADDR][5:4];
     csr_src_auto_start_num_a_o  = csr_set[DATA_SRC_AUTO_START_A_REG_ADDR];
     csr_src_auto_start_num_b_o  = csr_set[DATA_SRC_AUTO_START_B_REG_ADDR];
     csr_src_auto_num_a_o        = csr_set[DATA_SRC_AUTO_NUM_A_REG_ADDR];

--- a/rtl/csr/csr_addr_pkg.sv
+++ b/rtl/csr/csr_addr_pkg.sv
@@ -60,9 +60,10 @@ package csr_addr_pkg;
   localparam logic [ 4:0] INST_LOOP_COUNT_ADDR3_BIT_ADDR  = 5'd16;
 
   // Data slicer configurationsss
-  localparam logic [31:0] DATA_SRC_CTRL_REG_ADDR        = 32'd13;
-  localparam logic [ 4:0] DATA_SLICE_MODE_BIT_ADDR        = 5'd0;
-  localparam logic [ 4:0] DATA_SRC_SEL_BIT_ADDR           = 5'd0;
+  localparam logic [31:0] DATA_SRC_CTRL_REG_ADDR          = 32'd13;
+  localparam logic [ 4:0] DATA_SLICE_MODE_A_BIT_ADDR      = 5'd0;
+  localparam logic [ 4:0] DATA_SLICE_MODE_B_BIT_ADDR      = 5'd2;
+  localparam logic [ 4:0] DATA_SRC_SEL_BIT_ADDR           = 5'd4;
   localparam logic [31:0] DATA_SLICE_NUM_ELEM_A_REG_ADDR  = 32'd14;
   localparam logic [31:0] DATA_SLICE_NUM_ELEM_B_REG_ADDR  = 32'd15;
   localparam logic [31:0] DATA_SRC_AUTO_START_A_REG_ADDR  = 32'd16;

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -173,7 +173,8 @@ module hypercorex_top # (
   logic [InstMemAddrWidth-1:0]                   loop_count_addr2;
   logic [InstMemAddrWidth-1:0]                   loop_count_addr3;
   // Data slicer configurations
-  logic [ SlicerModeWidth-1:0]                   data_slice_mode;
+  logic [ SlicerModeWidth-1:0]                   data_slice_mode_a;
+  logic [ SlicerModeWidth-1:0]                   data_slice_mode_b;
   logic [    CsrDataWidth-1:0]                   data_slice_num_elem_a;
   logic [    CsrDataWidth-1:0]                   data_slice_num_elem_b;
   // Source select configurations
@@ -377,7 +378,8 @@ module hypercorex_top # (
     // Observable registers
     .csr_obs_logic_o            ( obs_logic_o           ),
     // Data slicer configurations
-    .csr_data_slice_mode_o        ( data_slice_mode       ),
+    .csr_data_slice_mode_a_o      ( data_slice_mode_a     ),
+    .csr_data_slice_mode_b_o      ( data_slice_mode_b     ),
     .csr_data_slice_num_elem_a_o  ( data_slice_num_elem_a ),
     .csr_data_slice_num_elem_b_o  ( data_slice_num_elem_b ),
     // Data source control
@@ -543,7 +545,7 @@ module hypercorex_top # (
     // Control inputs
     .enable_i             ( enable              ),
     .clr_i                ( clr                 ),
-    .sel_mode_i           ( data_slice_mode     ),
+    .sel_mode_i           ( data_slice_mode_a   ),
     // Settings
     .csr_elem_size_i      ( data_slice_num_elem_a ),
     // Data inputs
@@ -571,7 +573,7 @@ module hypercorex_top # (
     // Control inputs
     .enable_i             ( enable              ),
     .clr_i                ( clr                 ),
-    .sel_mode_i           ( data_slice_mode     ),
+    .sel_mode_i           ( data_slice_mode_b   ),
     // Settings
     .csr_elem_size_i      ( data_slice_num_elem_b ),
     // Data inputs

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -468,18 +468,23 @@ async def csr_dut(dut):
     golden_val = gen_rand_bits(set_parameters.REG_FILE_WIDTH)
     await write_csr(dut, golden_val, set_parameters.DATA_SRC_CTRL_REG_ADDR)
 
-    # Check value of data slice mode that is 2 LSB
+    # Check value of data slice mode for port A
     golden_val_slide_mode = golden_val & 0x0000_0003
-    test_val = dut.csr_data_slice_mode_o.value.integer
+    test_val = dut.csr_data_slice_mode_a_o.value.integer
+    check_result(test_val, golden_val_slide_mode)
+
+    # Check value of data slice mode for port B
+    golden_val_slide_mode = (golden_val >> 2) & 0x0000_0003
+    test_val = dut.csr_data_slice_mode_b_o.value.integer
     check_result(test_val, golden_val_slide_mode)
 
     # Check the value of source select also 2 bits long
-    golden_val_src_sel = (golden_val >> 2) & 0x0000_0003
+    golden_val_src_sel = (golden_val >> 4) & 0x0000_0003
     test_val = dut.csr_data_src_sel_o.value.integer
     check_result(test_val, golden_val_src_sel)
 
     # Read value manually
-    golden_val = golden_val & 0x0000_000F
+    golden_val = golden_val & 0x0000_003F
     csr_read_val = await read_csr(dut, set_parameters.DATA_SRC_CTRL_REG_ADDR)
     check_result(csr_read_val, golden_val)
 


### PR DESCRIPTION
This PR updates the CSR mechanism to separate the slice mode for a and b ports.

Major TODO:
- [x] Update the CSR
- [x] Update the top-level
- [x] Update CSR test