### PR TITLE
Update CI so that Char Recog Data Slice is in system tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
           --ignore=tests/test_tb_hypercorex.py \
           --ignore=tests/test_hypercorex_csr.py \
           --ignore=tests/test_hypercorex_char_recog.py \
-          --ignore=tests/test_hypercorex_ortho_im_only.py
+          --ignore=tests/test_hypercorex_ortho_im_only.py \
+          --ignore=tests/test_hypercorex_char_recog_data_slice.py
 
   rtl-system-tests-vlt:
     name: System Tests using Verilator
@@ -37,8 +38,8 @@ jobs:
           pytest -n $(nproc) --dist=loadfile \
           tests/test_hypercorex_csr.py \
           tests/test_hypercorex_char_recog.py \
-          tests/test_hypercorex_ortho_im_only.py
-
+          tests/test_hypercorex_ortho_im_only.py \
+          tests/test_hypercorex_char_recog_data_slice.py
   sw-test:
     name: Test Compiler for ASM
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR is a simple fix for the CI so that system tests are not part of the unit tests.