### PR TITLE
Add main README documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 The Hypercorex is a semi-data flow accelerator for binary [hyperdimensional computing](https://www.hd-computing.com/home) algorithms. The architecture is built using the same principles of building a generic CPU, but tailored for very large bit-widths. It also expects data to be streamed continuously for uninterrupted processing.
 
-Unlike typical data flow accelerators with fixed kernel operations, Hypercorex's semi-data flow architecture allows more configurability to support various encoding schemes to support state-of-the-art binary HDC operations. The key aspects are: (1) the CPU-like architecture to get as much configurability as possible, and (2) the process being able to handle data that are contuously fed into the accelerator.
+Unlike typical data flow accelerators with fixed kernel operations, Hypercorex's semi-data flow architecture allows more configurability to support various encoding schemes to support state-of-the-art binary HDC operations. The key aspects are: (1) the CPU-like architecture to get as much configurability as possible, and (2) the process being able to handle data that is continuously fed into the accelerator.
 
 More details can be found in (TODO: insert docs page here).
+
+![image](https://github.com/user-attachments/assets/e4cc1d97-5af7-418d-9cd7-44e2fc5ad718)
+
+
 
 # Getting Started
 
@@ -18,7 +22,7 @@ More details can be found in (TODO: insert docs page here).
 pip install -r requirements.txt
 ```
 
-- Pre-built container can be downloaded using [Docker](https://docs.docker.com/engine/install/). This already contains all the necessary intallations needed. Highly recommended to start right away.
+- Pre-built container can be downloaded using [Docker](https://docs.docker.com/engine/install/). This already contains all the necessary installations needed. Highly recommended to start right away.
 
 ```bash
 docker pull ghcr.io/kuleuven-micas/hypercorex:main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Hypercorex
+
+The Hypercorex is a semi-data flow accelerator for binary [hyperdimensional computing](https://www.hd-computing.com/home) algorithms. The architecture is built using the same principles of building a generic CPU, but tailored for very large bit-widths. It also expects data to be streamed continuously for uninterrupted processing.
+
+Unlike typical data flow accelerators with fixed kernel operations, Hypercorex's semi-data flow architecture allows more configurability to support various encoding schemes to support state-of-the-art binary HDC operations. The key aspects are: (1) the CPU-like architecture to get as much configurability as possible, and (2) the process being able to handle data that are contuously fed into the accelerator.
+
+More details can be found in (TODO: insert docs page here).
+
+# Getting Started
+
+## Requirements
+
+- You need [Verilator v5.006](https://verilator.org/guide/latest/install.html) for the open-source simulation tool. You may also use `modelsim` for a commercial tool.
+
+- Install all Python (3.10) requirements with:
+
+```bash
+pip install -r requirements.txt
+```
+
+- Pre-built container can be downloaded using [Docker](https://docs.docker.com/engine/install/). This already contains all the necessary intallations needed. Highly recommended to start right away.
+
+```bash
+docker pull ghcr.io/kuleuven-micas/hypercorex:main
+```
+
+## Running a Program
+
+There are several tests in the repository. To run a sample test:
+
+```bash
+pytest tests/test_hypercorex_char_recog.py
+```
+
+You can add `--simulator=modelsim` argument to run it in `modelsim`. The default uses `verilator`. You can also add `--waves=1` to dump waveforms. The `verilator` dumps a `.vcd` file, while `modelsim` dumps a `.wlf` file. For example:
+
+```bash
+pytest tests/test_hypercorex_char_recog.py --simulator=modelsim --waves=1
+```
+
+**Notes**:
+- The tests are run using [Cocotb](https://www.cocotb.org/) to handle more complex verification tasks.
+- Test descriptions can be found in the (TODO: insert link to test README)
+
+# Directory Structure
+- `hdc_exp`: Contains several HDC experiments for SW. Feel free to explore how some algorithms were tested.
+- `rtl`: Main directory for the RTL source files. The testbench RTL can also be found in here.
+- `sw`: This is for the compiled ASMs needed to feed into the instruction memory.
+- `tests`: This is where all unit and system tests for the RTL reside.
+- `util`: Contains utility functions tools like the Dockerfile, and generation scripts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ In this directory, we describe the details of the Hypercorex architecture, the t
 :triangular_ruler: **Hypercorex Architecture**
 
 - Instruction Control Operation
+- CSR Details
 - Data Slicer Operation
 - Item Memory Details
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# :blue_book: Hypercorex Documentation
+
+In this directory, we describe the details of the Hypercorex architecture, the testbench of the system, and the assembler used in this project.
+
+## Table of Docments
+
+:triangular_ruler: **Hypercorex Architecture**
+
+- Instruction Control Operation
+- Data Slicer Operation
+- Item Memory Details
+
+
+:page_with_curl: **Instructing the Accelerator**
+
+:construction_worker: **Testbench Architecture**

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,39 @@
+# :hammer: Tests Directory
+
+This directory has a mix of unit tests and system tests. Each are briefly described below:
+
+## :zap: Utility Files
+:zap: [`set_parameters.py`](set_parameters.py): contains all parameters used for testing the Hypercorex
+:zap: [`util.py`](util.py): contains utility functions used in all other tests.
+
+## :nut_and_bolt: Fucntional Unit Tests
+:nut_and_bolt: [`test_assoc_mem.py`](test_assoc_mem.py): associative memory capabilities.
+:nut_and_bolt: [`test_bundler_set.py`](test_bundler_set.py): a bundler set (i.e., multiple bundler units).
+:nut_and_bolt: [`test_bundler_unit.py`](test_bundler_unit.py): a single bundler unit test.
+:nut_and_bolt: [`test_ca90_item_memory.py`](test_ca90_item_memory.py): tests the orthogonal projection of the CA90 item memory.
+:nut_and_bolt: [`test_cim.py`](test_cim.py): tests the continuous item memory.
+:nut_and_bolt: [`test_csr.py`](test_csr.py): functionality and read-write capabilities of the CSR block.
+:nut_and_bolt: [`test_data_slicer.py`](test_data_slicer.py): checks functionality of the data slicer for different bit-widths.
+:nut_and_bolt: [`test_fifo.py`](test_fifo.py): simple FIFO checker.
+:nut_and_bolt: [`test_fixed_ca90_unit.py`](test_fixed_ca90_unit.py): tests the single CA90 XOR and shift unit.
+:nut_and_bolt: [`test_ham_dist.py`](test_ham_dist.py): simple checker if the Hamming distance unit counts correctly.
+:nut_and_bolt: [`test_hv_alu_pe.py`](test_hv_alu_pe.py): unit checker for the logic of the encoder processing element.
+:nut_and_bolt: [`test_hv_encoder.py`](test_hv_encoder.py): the main encoder module test.
+:nut_and_bolt: [`test_inst_control.py`](test_inst_control.py): test the loops of the instruction control.
+:nut_and_bolt: [`test_inst_decode.py`](test_inst_decode.py): check the decoded outputs of the instruction decoder.
+:nut_and_bolt: [`test_item_memory_top.py`](test_item_memory_top.py): check the top-level of the item memory block.
+:nut_and_bolt: [`test_item_memory.py`](test_item_memory.py): check the combined orthogonal iM and CiM.
+:nut_and_bolt: [`test_reg_file_1w1r.py`](test_reg_file_1w1r.py): test register file for 1 write and 1 read port.
+:nut_and_bolt: [`test_reg_file_1w2r.py`](test_reg_file_1w2r.py): test register file for 1 write and 2 read ports.
+:nut_and_bolt: [`test_rom_item_memory.py`](test_rom_item_memory.py): read-only item memory.
+:nut_and_bolt: [`test_update_counter.py`](test_update_counter.py): test the update counter for automatic fetching.
+
+
+## :iphone: System Tests
+:iphone: [`test_hypercorex_am_search.py`](test_hypercorex_am_search.py): checker if the AM continuous search works.
+:iphone: [`test_hypercorex_char_recog_data_slice.py`](test_hypercorex_char_recog_data_slice.py): checker data slicing capabilities works well with the character recognition example.
+:iphone: [`test_hypercorex_char_recog.py`](test_hypercorex_char_recog.py): character recognition application but the pixel values and pixel locations are binded instead of permuting if white or black.
+:iphone: [`test_hypercorex_csr.py`](test_hypercorex_csr.py): also a CSR test but uses the system control ports for checking read-write operations.
+:iphone: [`test_hypercorex_imab_bind.py`](test_hypercorex_imab_bind.py): tests if the continuous binding and outputting high-dimensional data are consistent.
+:iphone: [`test_hypercorex_ortho_im_only.py`](test_hypercorex_ortho_im_only.py): checks the contests of the internal orthogonal item memory.
+:iphone: [`test_tb_hypercorex.py`](test_tb_hypercorex.py): tests the testbench only.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,37 +3,65 @@
 This directory has a mix of unit tests and system tests. Each are briefly described below:
 
 ## :zap: Utility Files
+
 :zap: [`set_parameters.py`](set_parameters.py): contains all parameters used for testing the Hypercorex
+
 :zap: [`util.py`](util.py): contains utility functions used in all other tests.
 
 ## :nut_and_bolt: Fucntional Unit Tests
+
 :nut_and_bolt: [`test_assoc_mem.py`](test_assoc_mem.py): associative memory capabilities.
+
 :nut_and_bolt: [`test_bundler_set.py`](test_bundler_set.py): a bundler set (i.e., multiple bundler units).
+
 :nut_and_bolt: [`test_bundler_unit.py`](test_bundler_unit.py): a single bundler unit test.
+
 :nut_and_bolt: [`test_ca90_item_memory.py`](test_ca90_item_memory.py): tests the orthogonal projection of the CA90 item memory.
+
 :nut_and_bolt: [`test_cim.py`](test_cim.py): tests the continuous item memory.
+
 :nut_and_bolt: [`test_csr.py`](test_csr.py): functionality and read-write capabilities of the CSR block.
+
 :nut_and_bolt: [`test_data_slicer.py`](test_data_slicer.py): checks functionality of the data slicer for different bit-widths.
+
 :nut_and_bolt: [`test_fifo.py`](test_fifo.py): simple FIFO checker.
+
 :nut_and_bolt: [`test_fixed_ca90_unit.py`](test_fixed_ca90_unit.py): tests the single CA90 XOR and shift unit.
+
 :nut_and_bolt: [`test_ham_dist.py`](test_ham_dist.py): simple checker if the Hamming distance unit counts correctly.
+
 :nut_and_bolt: [`test_hv_alu_pe.py`](test_hv_alu_pe.py): unit checker for the logic of the encoder processing element.
+
 :nut_and_bolt: [`test_hv_encoder.py`](test_hv_encoder.py): the main encoder module test.
+
 :nut_and_bolt: [`test_inst_control.py`](test_inst_control.py): test the loops of the instruction control.
+
 :nut_and_bolt: [`test_inst_decode.py`](test_inst_decode.py): check the decoded outputs of the instruction decoder.
+
 :nut_and_bolt: [`test_item_memory_top.py`](test_item_memory_top.py): check the top-level of the item memory block.
+
 :nut_and_bolt: [`test_item_memory.py`](test_item_memory.py): check the combined orthogonal iM and CiM.
+
 :nut_and_bolt: [`test_reg_file_1w1r.py`](test_reg_file_1w1r.py): test register file for 1 write and 1 read port.
+
 :nut_and_bolt: [`test_reg_file_1w2r.py`](test_reg_file_1w2r.py): test register file for 1 write and 2 read ports.
+
 :nut_and_bolt: [`test_rom_item_memory.py`](test_rom_item_memory.py): read-only item memory.
+
 :nut_and_bolt: [`test_update_counter.py`](test_update_counter.py): test the update counter for automatic fetching.
 
-
 ## :iphone: System Tests
+
 :iphone: [`test_hypercorex_am_search.py`](test_hypercorex_am_search.py): checker if the AM continuous search works.
+
 :iphone: [`test_hypercorex_char_recog_data_slice.py`](test_hypercorex_char_recog_data_slice.py): checker data slicing capabilities works well with the character recognition example.
+
 :iphone: [`test_hypercorex_char_recog.py`](test_hypercorex_char_recog.py): character recognition application but the pixel values and pixel locations are binded instead of permuting if white or black.
+
 :iphone: [`test_hypercorex_csr.py`](test_hypercorex_csr.py): also a CSR test but uses the system control ports for checking read-write operations.
+
 :iphone: [`test_hypercorex_imab_bind.py`](test_hypercorex_imab_bind.py): tests if the continuous binding and outputting high-dimensional data are consistent.
+
 :iphone: [`test_hypercorex_ortho_im_only.py`](test_hypercorex_ortho_im_only.py): checks the contests of the internal orthogonal item memory.
+
 :iphone: [`test_tb_hypercorex.py`](test_tb_hypercorex.py): tests the testbench only.


### PR DESCRIPTION
This PR adds the main README document.

Major TODO:
- [x] Add the main README document to the root.
- [x] Add README for the tests.
- [x] Add and create a docs directory and start the main README from there.

Future TODO:
- Fill in the contents of the main README documentation.