### PR TITLE
Add expand IM option

### DIFF
--- a/hdc_exp/digit_recog.py
+++ b/hdc_exp/digit_recog.py
@@ -17,6 +17,7 @@ from hdc_util import (
     retrain_model,
     gen_empty_hv,
     gen_orthogonal_im,
+    expand_im,
     bind_hv,
     binarize_hv,
     gen_ca90_im_set,
@@ -51,11 +52,13 @@ def encode_digit(image, ortho_im, cim):
 
 if __name__ == "__main__":
     SEED_DIM = 32
-    HV_DIM = 4096
+    HV_DIM = 512
+    ENABLE_HV_EXPANSION = True
+    HV_DIM_EXPANSION = 16
     NUM_TOT_IM = 1024
     NUM_PER_IM_BANK = 128
     NGRAM = 4
-    USE_CA90_IM = False
+    USE_CA90_IM = True
     EXTRACT_DATA = True
 
     NUM_CLASSES = 10
@@ -103,6 +106,9 @@ if __name__ == "__main__":
             hv_type="binary",
             im_type="random",
         )
+
+    if ENABLE_HV_EXPANSION:
+        ortho_im = expand_im(ortho_im, HV_DIM_EXPANSION)
 
     print("Extracting data...")
     train_data = dict()

--- a/hdc_exp/dna_recog.py
+++ b/hdc_exp/dna_recog.py
@@ -17,6 +17,7 @@ from hdc_util import (
     retrain_model,
     gen_empty_hv,
     gen_orthogonal_im,
+    expand_im,
     bind_hv,
     binarize_hv,
     gen_ca90_im_set,
@@ -57,10 +58,12 @@ def encode_dna(seq, ortho_im, cim):
 if __name__ == "__main__":
     SEED_DIM = 32
     HV_DIM = 512
+    ENABLE_HV_EXPANSION = True
+    HV_DIM_EXPANSION = 16
     NUM_TOT_IM = 1024
     NUM_PER_IM_BANK = 128
     NGRAM = 4
-    USE_CA90_IM = True
+    USE_CA90_IM = False
     EXTRACT_DATA = True
 
     NUM_CLASSES = 3
@@ -108,6 +111,9 @@ if __name__ == "__main__":
             hv_type="binary",
             im_type="random",
         )
+
+    if ENABLE_HV_EXPANSION:
+        ortho_im = expand_im(ortho_im, HV_DIM_EXPANSION)
 
     print("Extracting data...")
     train_data = dict()

--- a/hdc_exp/hdc_util.py
+++ b/hdc_exp/hdc_util.py
@@ -11,12 +11,14 @@
 
 import numpy as np
 from tqdm import tqdm
+from collections import Counter
 import matplotlib.pyplot as plt
 import requests
 import tarfile
 import io
 import copy
 import math
+
 
 """
     General functions
@@ -112,7 +114,7 @@ def one_sample_per_class(
         for i in range(num_classes):
             line = " ".join(map(str, test_data[i][class_and_idx[i]]))
             wf.write(line + "\n")
-    return
+    return class_and_idx
 
 
 # Convert from one uint level to another
@@ -479,6 +481,21 @@ def ca90_extract_seeds(seed_size, seed_num, hv_dim, ca90_mode="iter", debug_info
         print(f"Number of seeds: {seed_num}")
 
     return seed_list
+
+# Expansion of IM
+def expand_im(ortho_im, expansion_multiplier):
+    num_rows = len(ortho_im)
+    hv_dim = len(ortho_im[0])
+    ortho_im_expanded = gen_empty_mem_hv(num_rows,hv_dim*expansion_multiplier)
+    for i in range(expansion_multiplier):
+        ortho_im_expanded[:,i*hv_dim:(i+1)*hv_dim] = np.roll(ortho_im, shift=-1*i, axis=0)
+    return ortho_im_expanded.astype(int)
+
+def expand_cim(cim,expansion_multiplier):
+    cim_expanded = copy.deepcopy(cim)
+    for i in range(expansion_multiplier-1):
+        cim_expanded = np.concatenate((cim_expanded,cim),axis=1)
+    return cim_expanded
 
 
 # Generating orthogonal item memory
@@ -892,13 +909,64 @@ def retrain_model(
     return class_am_copy, class_am_int_copy, class_am_elem_count_copy
 
 
+def train_ensemble_model(train_dataset, num_train, num_ensemble, ensemble_ortho_im, cim, encode_function, tqdm_mode=0):
+    ensemble_am = dict()
+    
+    for i in range(num_ensemble):
+    
+        class_am, _, _ = train_model(
+            train_dataset=train_dataset,
+            num_train=num_train,
+            ortho_im=ensemble_ortho_im[i],
+            cim=cim,
+            encode_function=encode_function,
+            tqdm_mode=tqdm_mode,
+        )
+        
+        ensemble_am[i] = class_am
+    return ensemble_am
+
+
+def test_ensemble_model(test_data, ensemble_am, ensemble_ortho_im, cim, num_ensemble, num_test, encode_function):
+    num_classes = len(ensemble_am[0])
+    # Class prediction set
+    class_predict_set = []
+    for class_num in range(num_classes):
+        # First make a prediction per ensemble
+        pred_set_list = []
+        for i in tqdm(range(num_ensemble)):
+            qhv_list = []
+            for j in range(num_test):
+                qhv = encode_function(test_data[class_num][j], ensemble_ortho_im[i], cim)
+                qhv_list.append(qhv)
+        
+            sample_pred_set = prediction_set(ensemble_am[i], qhv_list)
+            pred_set_list.append(sample_pred_set)
+
+        
+        # Then we do majority voting on ensemble
+        final_predict_set = []
+        for i in range(len(pred_set_list[0])):
+            ensemble_predict = []
+            # Append to the list the predictions
+            for j in range(len(pred_set_list)):
+                ensemble_predict.append(pred_set_list[j][i])
+            # Do majority counting
+            counter = Counter(ensemble_predict)
+            # Return majority
+            majority_element, count = counter.most_common(1)[0]
+            final_predict_set.append(majority_element)
+            
+        class_predict_set.append(final_predict_set)
+
+    return class_predict_set
+
 def predict_item(ortho_im, cim, class_am, sample, encode_function, hv_type="binary"):
     # Encode value
     qhv = encode_function(sample, ortho_im, cim)
     # Get prediction
     prediction = prediction_idx(class_am, qhv, hv_type=hv_type)
     return prediction
-
 
 """
     Functions for testing purposes

--- a/hdc_exp/hdc_util.py
+++ b/hdc_exp/hdc_util.py
@@ -399,6 +399,15 @@ def gen_conf_mat(num_levels, hv_list):
 
     gen_square_cim:
         - Generates a square cim that is half of the dimension size
+
+    expand_im:
+        - This expands the orthogonal IM by some multiplier
+        the expansion is done based on re-using a given ortho_IM set
+
+    expand_cim:
+        - This expands the cim by some multiplier
+        the expansion is simply a concatenation as it retains the
+        effective similarity levels
 """
 
 
@@ -482,19 +491,23 @@ def ca90_extract_seeds(seed_size, seed_num, hv_dim, ca90_mode="iter", debug_info
 
     return seed_list
 
+
 # Expansion of IM
 def expand_im(ortho_im, expansion_multiplier):
     num_rows = len(ortho_im)
     hv_dim = len(ortho_im[0])
-    ortho_im_expanded = gen_empty_mem_hv(num_rows,hv_dim*expansion_multiplier)
+    ortho_im_expanded = gen_empty_mem_hv(num_rows, hv_dim * expansion_multiplier)
     for i in range(expansion_multiplier):
-        ortho_im_expanded[:,i*hv_dim:(i+1)*hv_dim] = np.roll(ortho_im, shift=-1*i, axis=0)
+        ortho_im_expanded[:, i * hv_dim : (i + 1) * hv_dim] = np.roll(
+            ortho_im, shift=-1 * i, axis=0
+        )
     return ortho_im_expanded.astype(int)
 
-def expand_cim(cim,expansion_multiplier):
+
+def expand_cim(cim, expansion_multiplier):
     cim_expanded = copy.deepcopy(cim)
-    for i in range(expansion_multiplier-1):
-        cim_expanded = np.concatenate((cim_expanded,cim),axis=1)
+    for i in range(expansion_multiplier - 1):
+        cim_expanded = np.concatenate((cim_expanded, cim), axis=1)
     return cim_expanded
 
 
@@ -909,11 +922,18 @@ def retrain_model(
     return class_am_copy, class_am_int_copy, class_am_elem_count_copy
 
 
-def train_ensemble_model(train_dataset, num_train, num_ensemble, ensemble_ortho_im, cim, encode_function, tqdm_mode=0):
+def train_ensemble_model(
+    train_dataset,
+    num_train,
+    num_ensemble,
+    ensemble_ortho_im,
+    cim,
+    encode_function,
+    tqdm_mode=0,
+):
     ensemble_am = dict()
-    
+
     for i in range(num_ensemble):
-    
         class_am, _, _ = train_model(
             train_dataset=train_dataset,
             num_train=num_train,
@@ -922,12 +942,20 @@ def train_ensemble_model(train_dataset, num_train, num_ensemble, ensemble_ortho_
             encode_function=encode_function,
             tqdm_mode=tqdm_mode,
         )
-        
+
         ensemble_am[i] = class_am
     return ensemble_am
 
 
-def test_ensemble_model(test_data, ensemble_am, ensemble_ortho_im, cim, num_ensemble, num_test, encode_function):
+def test_ensemble_model(
+    test_data,
+    ensemble_am,
+    ensemble_ortho_im,
+    cim,
+    num_ensemble,
+    num_test,
+    encode_function,
+):
     num_classes = len(ensemble_am[0])
     # Class prediction set
     class_predict_set = []
@@ -937,13 +965,14 @@ def test_ensemble_model(test_data, ensemble_am, ensemble_ortho_im, cim, num_ense
         for i in tqdm(range(num_ensemble)):
             qhv_list = []
             for j in range(num_test):
-                qhv = encode_function(test_data[class_num][j], ensemble_ortho_im[i], cim)
+                qhv = encode_function(
+                    test_data[class_num][j], ensemble_ortho_im[i], cim
+                )
                 qhv_list.append(qhv)
-        
+
             sample_pred_set = prediction_set(ensemble_am[i], qhv_list)
             pred_set_list.append(sample_pred_set)
 
-        
         # Then we do majority voting on ensemble
         final_predict_set = []
         for i in range(len(pred_set_list[0])):
@@ -956,10 +985,11 @@ def test_ensemble_model(test_data, ensemble_am, ensemble_ortho_im, cim, num_ense
             # Return majority
             majority_element, count = counter.most_common(1)[0]
             final_predict_set.append(majority_element)
-            
+
         class_predict_set.append(final_predict_set)
 
     return class_predict_set
+
 
 def predict_item(ortho_im, cim, class_am, sample, encode_function, hv_type="binary"):
     # Encode value
@@ -967,6 +997,7 @@ def predict_item(ortho_im, cim, class_am, sample, encode_function, hv_type="bina
     # Get prediction
     prediction = prediction_idx(class_am, qhv, hv_type=hv_type)
     return prediction
+
 
 """
     Functions for testing purposes

--- a/hdc_exp/isolet_recog.py
+++ b/hdc_exp/isolet_recog.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     NUM_PER_IM_BANK = 128
     NGRAM = 4
     USE_CA90_IM = True
-    USE_CA90_CIM = False
+    USE_CA90_CIM = True
     EXTRACT_DATA = True
 
     VAL_LEVELS = 21

--- a/hdc_exp/isolet_recog.py
+++ b/hdc_exp/isolet_recog.py
@@ -18,10 +18,13 @@ from hdc_util import (
     retrain_model,
     gen_empty_hv,
     gen_orthogonal_im,
+    expand_im,
+    expand_cim,
     bind_hv,
     binarize_hv,
     gen_ca90_im_set,
     gen_cim,
+    gen_square_cim,
 )
 
 DATA_URL = "https://github.com/KULeuven-MICAS/hypercorex/releases/download/ds_hdc_isolet_recog_v.0.01/isolet_recog.tar.gz"
@@ -57,12 +60,15 @@ def encode_isolet(sample, ortho_im, cim):
 
 if __name__ == "__main__":
     SEED_DIM = 32
-    HV_DIM = 10000
+    HV_DIM = 512
+    ENABLE_HV_EXPANSION = True
+    HV_DIM_EXPANSION = 16
     NUM_TOT_IM = 1024
     NUM_PER_IM_BANK = 128
     NGRAM = 4
-    USE_CA90_IM = False
-    EXTRACT_DATA = False
+    USE_CA90_IM = True
+    USE_CA90_CIM = False
+    EXTRACT_DATA = True
 
     VAL_LEVELS = 21
     NUM_CLASSES = 26
@@ -112,17 +118,31 @@ if __name__ == "__main__":
             im_type="random",
         )
 
-    cim = gen_cim(
-        hv_dim=HV_DIM,
-        seed_size=32,
-        num_hv=VAL_LEVELS,
-        base_seed=CIM_BASE_SEED,
-        gen_seed=False,
-        max_ortho=False,
-        im_type="random",
-        hv_type="binary",
-        debug_info=False,
-    )
+    if USE_CA90_CIM:
+        _, cim = gen_square_cim(
+            hv_dim=HV_DIM,
+            seed_size=32,
+            base_seed=CIM_BASE_SEED,
+            gen_seed=False,
+            im_type="ca90_hier",
+            debug_info=False,
+        )
+    else:
+        cim = gen_cim(
+            hv_dim=HV_DIM,
+            seed_size=32,
+            num_hv=VAL_LEVELS,
+            base_seed=CIM_BASE_SEED,
+            gen_seed=False,
+            max_ortho=True,
+            im_type="random",
+            hv_type="binary",
+            debug_info=False,
+        )
+
+    if ENABLE_HV_EXPANSION:
+        ortho_im = expand_im(ortho_im, HV_DIM_EXPANSION)
+        cim = expand_cim(cim, HV_DIM_EXPANSION)
 
     print("Extracting data...")
     train_data = dict()
@@ -139,8 +159,12 @@ if __name__ == "__main__":
         test_data[num_class] = load_dataset(read_file)
 
     print("Converting data...")
-    train_data = convert_levels(train_data, VAL_LEVELS)
-    test_data = convert_levels(test_data, VAL_LEVELS)
+    if USE_CA90_CIM:
+        train_data = convert_levels(train_data, VAL_LEVELS, VAL_LEVELS - 1)
+        test_data = convert_levels(test_data, VAL_LEVELS, VAL_LEVELS - 1)
+    else:
+        train_data = convert_levels(train_data, VAL_LEVELS)
+        test_data = convert_levels(test_data, VAL_LEVELS)
 
     print("Training model...")
     class_am, class_am_int, class_am_elem_count = train_model(

--- a/hdc_exp/lang_recog.py
+++ b/hdc_exp/lang_recog.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     NUM_TOT_IM = 1024
     NUM_PER_IM_BANK = 128
     NGRAM = 4
-    USE_CA90_IM = False
+    USE_CA90_IM = True
     EXTRACT_DATA = True
 
     NUM_TRAIN = 999

--- a/hdc_exp/ucihar_recog.py
+++ b/hdc_exp/ucihar_recog.py
@@ -68,10 +68,10 @@ if __name__ == "__main__":
     NUM_PER_IM_BANK = 128
     NGRAM = 4
     USE_CA90_IM = True
-    USE_CA90_CIM = False
+    USE_CA90_CIM = True
     EXTRACT_DATA = True
 
-    VAL_LEVELS = 21
+    VAL_LEVELS = 5
     NUM_CLASSES = 6
     NUM_TRAIN = 511
     NUM_RETRAIN = NUM_TRAIN


### PR DESCRIPTION
This PR is the 1st after the freeze for the HEMAIA project. Here, we add the mechanism to expand the IM from the re-used orthogonal IM and CiM in HEMAIA.

This way, we can save up on resources and make the expansion elegant. The catch is a multi-step of handling more dimensions.

For example, to process $D=4,096$, and currently Hypercorex uses $D=512$, we need to process sub-chunks of $D=512$ in 8 steps. So process the first 512 elements first, then the next 512. Essentially, vector folding.