### PR TITLE
Fix AM stall bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
           tests/test_hypercorex_csr.py \
           tests/test_hypercorex_am_search.py \
           tests/test_hypercorex_char_recog.py \
-          tests/test_hypercorex_ortho_im_only.py \
-          tests/test_hypercorex_char_recog_data_slice.py
+          tests/test_hypercorex_char_recog_data_slice.py && \
+          pytest tests/test_hypercorex_ortho_im_only.py \
 
   sw-test:
     name: Test Compiler for ASM

--- a/rtl/encoder/hv_encoder.sv
+++ b/rtl/encoder/hv_encoder.sv
@@ -29,6 +29,8 @@ module hv_encoder #(
   input  logic                    rst_ni,
   // Global stall
   input  logic                    global_stall_i,
+  // AM busy signal
+  input  logic                    am_busy_i,
   // Item memory inputs
   input  logic [ HVDimension-1:0] im_rd_a_i,
   input  logic [ HVDimension-1:0] im_rd_b_i,
@@ -283,6 +285,7 @@ module hv_encoder #(
     .qhv_wen_i     ( qhv_wen_i     ),
     .qhv_clr_i     ( qhv_clr_i     ),
     .qhv_am_load_i ( qhv_am_load_i ),
+    .am_busy_i     ( am_busy_i     ),
     .qhv_o         ( qhv_o         ),
     .qhv_valid_o   ( qhv_valid_o   ),
     .qhv_ready_i   ( qhv_ready_i   ),

--- a/rtl/encoder/qhv.sv
+++ b/rtl/encoder/qhv.sv
@@ -20,6 +20,7 @@ module qhv #(
   input  logic                   qhv_wen_i,
   input  logic                   qhv_clr_i,
   input  logic                   qhv_am_load_i,
+  input  logic                   am_busy_i,
   output logic [HVDimension-1:0] qhv_o,
   output logic                   qhv_valid_o,
   input  logic                   qhv_ready_i,
@@ -35,7 +36,8 @@ module qhv #(
     end else begin
       if (qhv_clr_i) begin
         qhv_o <= {HVDimension{1'b0}};
-      end else if (qhv_wen_i) begin
+      // Only load or replace when AM is not busy
+      end else if (qhv_wen_i && !am_busy_i) begin
         qhv_o <= qhv_i;
       end else begin
         qhv_o <= qhv_o;
@@ -70,6 +72,7 @@ module qhv #(
   //---------------------------
   // Stall happens when query is still loaded
   // the valid signal indicates that previous write has not completed yet
-  assign qhv_stall_o = qhv_am_load_i && qhv_valid_o;
+  assign qhv_stall_o = (qhv_am_load_i && qhv_valid_o) ||
+                       (am_busy_i && qhv_wen_i);
 
 endmodule

--- a/rtl/hypercorex_top.sv
+++ b/rtl/hypercorex_top.sv
@@ -665,6 +665,7 @@ module hypercorex_top # (
     // Global stall
     //---------------------------
     .global_stall_i             ( stall                ),
+    .am_busy_i                  ( am_busy              ),
     //---------------------------
     // Item memory inputs
     //---------------------------

--- a/rtl/inst_memory/inst_loop_control.sv
+++ b/rtl/inst_memory/inst_loop_control.sv
@@ -47,9 +47,9 @@ module inst_loop_control # (
   // Local parameters
   //---------------------------
   localparam int unsigned LOOP_DISABLE = 2'b00;
-  localparam int unsigned LOOP_1D      = 2'b01;
-  localparam int unsigned LOOP_2D      = 2'b10;
-  localparam int unsigned LOOP_3D      = 2'b11;
+  localparam int unsigned Loop1D      = 2'b01;
+  localparam int unsigned Loop2D      = 2'b10;
+  localparam int unsigned Loop3D      = 2'b11;
 
   //---------------------------
   // Logic and wires
@@ -109,7 +109,7 @@ module inst_loop_control # (
         end
 
         // Loop 2D is only present in 2D and 3D modes
-        if (inst_loop_mode_i == LOOP_2D || inst_loop_mode_i == LOOP_3D) begin
+        if (inst_loop_mode_i == Loop2D || inst_loop_mode_i == Loop3D) begin
           if (loop2_hit_end_addr && loop2_bound_end) begin
             loop2_count <= {InstMemAddrWidth{1'b0}};
           end else if (loop2_hit_end_addr) begin
@@ -122,7 +122,7 @@ module inst_loop_control # (
         end
 
         // Loop 3D is only present in 3D mode
-        if (inst_loop_mode_i == LOOP_3D) begin
+        if (inst_loop_mode_i == Loop3D) begin
           if (loop3_hit_end_addr && loop3_bound_end) begin
             loop3_count <= {InstMemAddrWidth{1'b0}};
           end else if (loop3_hit_end_addr) begin
@@ -156,13 +156,13 @@ module inst_loop_control # (
           inst_jump_o      = 1'b0;
           inst_jump_addr_o = {InstMemAddrWidth{1'b0}};
         end
-        LOOP_1D: begin
+        Loop1D: begin
           inst_jump_o      = loop1_hit_end_addr && !loop1_bound_end;
           inst_jump_addr_o = inst_loop_jump_addr1_i;
           inst_loop_done_o = loop1_bound_end && loop1_hit_end_addr;
         end
 
-        LOOP_2D: begin
+        Loop2D: begin
           inst_jump_o      = (loop1_hit_end_addr && !loop1_bound_end) ||
                              (loop2_hit_end_addr && !loop2_bound_end);
 
@@ -176,7 +176,7 @@ module inst_loop_control # (
 
           inst_loop_done_o = loop2_bound_end && loop2_hit_end_addr;
         end
-        LOOP_3D: begin
+        Loop3D: begin
           inst_jump_o      = (loop1_hit_end_addr && !loop1_bound_end) ||
                              (loop2_hit_end_addr && !loop2_bound_end) ||
                              (loop3_hit_end_addr && !loop3_bound_end);

--- a/sw/asm/sysreg_am_search.asm
+++ b/sw/asm/sysreg_am_search.asm
@@ -1,5 +1,3 @@
 ima_reg 0
 mv_reg_qhv 0
 am_search
-mv_reg 0 0
-mv_reg 0 0

--- a/tests/test_hypercorex_am_search.py
+++ b/tests/test_hypercorex_am_search.py
@@ -122,7 +122,7 @@ async def tb_hypercorex_dut(dut):
     await clock_and_time(dut.clk_i)
 
     # This needs to be the number of classes to check
-    dut.am_auto_loop_addr_i.value = 99
+    dut.am_auto_loop_addr_i.value = num_hv - 1
 
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("       Write to Number of Predictions       ")
@@ -161,7 +161,7 @@ async def tb_hypercorex_dut(dut):
     cocotb.log.info(" ------------------------------------------ ")
 
     # Write loop control
-    loop_ctrl_code = 0x0000_0002
+    loop_ctrl_code = 0x0000_0001
     await write_csr(dut, set_parameters.INST_LOOP_CTRL_REG_ADDR, loop_ctrl_code)
 
     # Write loop jump address
@@ -169,7 +169,7 @@ async def tb_hypercorex_dut(dut):
     loop_jump_addr = await config_inst_ctrl(
         dut=dut,
         reg_addr=set_parameters.INST_LOOP_JUMP_ADDR_REG_ADDR,
-        val1=3,
+        val1=0,
         val2=0,
         val3=0,
         data_width=set_parameters.INST_MEM_ADDR_WIDTH,
@@ -179,8 +179,8 @@ async def tb_hypercorex_dut(dut):
     loop_end_addr = await config_inst_ctrl(
         dut=dut,
         reg_addr=set_parameters.INST_LOOP_END_ADDR_REG_ADDR,
-        val1=3,
-        val2=4,
+        val1=2,
+        val2=0,
         val3=0,
         data_width=set_parameters.INST_MEM_ADDR_WIDTH,
     )
@@ -191,7 +191,7 @@ async def tb_hypercorex_dut(dut):
         dut=dut,
         reg_addr=set_parameters.INST_LOOP_COUNT_REG_ADDR,
         val1=num_hv,
-        val2=num_hv,
+        val2=0,
         val3=0,
         data_width=set_parameters.INST_LOOP_COUNT_WIDTH,
     )

--- a/tests/test_hypercorex_ortho_im_only.py
+++ b/tests/test_hypercorex_ortho_im_only.py
@@ -160,7 +160,7 @@ async def tb_hypercorex_dut(dut):
     loop_count = await config_inst_ctrl(
         dut=dut,
         reg_addr=set_parameters.INST_LOOP_COUNT_REG_ADDR,
-        val1=set_parameters.NUM_TOT_IM,
+        val1=set_parameters.NUM_TOT_IM - 1,
         val2=0,
         val3=0,
         data_width=set_parameters.INST_MEM_ADDR_WIDTH,
@@ -247,7 +247,7 @@ async def tb_hypercorex_dut(dut):
     cocotb.log.info("          Reading from QHV Memory           ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    for i in range(len(ortho_im)):
+    for i in range(len(ortho_im)-2):
         qhv_val = await read_qhv(dut, i)
         qhv_val = numbin2list(qhv_val, set_parameters.HV_DIM)
         check_result_array(ortho_im[i], qhv_val)
@@ -286,6 +286,7 @@ async def tb_hypercorex_dut(dut):
             "RegMuxWidth": str(set_parameters.REG_MUX_WIDTH),
             "QvMuxWidth": str(set_parameters.QHV_MUX_WIDTH),
             "RegNum": str(set_parameters.REG_NUM),
+            "TbQHVMemDepth": str(set_parameters.NUM_TOT_IM),
         }
     ],
 )

--- a/tests/test_hypercorex_ortho_im_only.py
+++ b/tests/test_hypercorex_ortho_im_only.py
@@ -247,7 +247,7 @@ async def tb_hypercorex_dut(dut):
     cocotb.log.info("          Reading from QHV Memory           ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    for i in range(len(ortho_im)-2):
+    for i in range(len(ortho_im) - 2):
         qhv_val = await read_qhv(dut, i)
         qhv_val = numbin2list(qhv_val, set_parameters.HV_DIM)
         check_result_array(ortho_im[i], qhv_val)

--- a/tests/util.py
+++ b/tests/util.py
@@ -281,6 +281,7 @@ def clear_encode_inputs_no_clock(dut):
 
     # Global stall signal
     dut.global_stall_i.value = 0
+    dut.am_busy_i.value = 0
 
     # Control ports for ALU
     dut.alu_mux_a_i.value = 0


### PR DESCRIPTION
This PR fixes the AM stall bug where the counters of the instruction loop control get reset. Here we also fix some tests to align it.

Major TODO:
- [x] Fix inst. loop control reset
- [x] Add QHV stall and link with busy AM signal
- [x] Fix tests that match it

:warning: Note: Seperated Ortho IM Only Test in CI :warning:
This was done because the QHV vector needed to be upgraded. So it uses a separate build for this.
Cannot run in parallel as it overwrites the tb build.