### PR TITLE
Add VSA models library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,16 @@ jobs:
 
       - name: Run library check
         run: pixi run lib-check
+
+  model-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+
+      - name: Run model check
+        run: pixi run model-check

--- a/lib/vsax.py
+++ b/lib/vsax.py
@@ -24,6 +24,47 @@ LFSR_TAP_MASK = 0xB4BC_D35C  # primitive polynomial — maximal-length 32-bit LF
 LFSR_KNUTH_CONST = 0x9E37_79B9  # floor(2^32 / φ) — Knuth multiplicative hash
 LFSR_WARMUP_STEPS = 32  # warm-up iterations inside lfsr_item_seed
 
+
+# ---------------------------------------------------------------------------
+# Auxiliary functions
+# ---------------------------------------------------------------------------
+# Random flipping of bits in a hypervector
+def hv_rand_flip(
+    hv: np.ndarray, start_flips: int, end_flips: int, hv_type: str = "binary"
+) -> np.ndarray:
+    """
+    Randomly flip bits in a hypervector.
+
+    Parameters:
+        hv (np.ndarray): The hypervector to flip bits in.
+        start_flips (int): The starting index for flipping.
+        end_flips (int): The ending index for flipping.
+        hv_type (str): The type of hypervector. Can be 'bipolar'
+
+    Returns:
+        np.ndarray: The hypervector with flipped bits.
+    """
+    if hv_type == "bipolar":
+        hv[start_flips:end_flips] *= -1
+    else:
+        hv[start_flips:end_flips] ^= 1
+    return hv
+
+
+# Prediction from an existing class AM and an encoded hypervector
+def hv_prediction_idx(
+    class_am: np.ndarray, encoded_hv: np.ndarray, hv_type: str = "bipolar"
+) -> int:
+    if hv_type == "binary":
+        score = (class_am ^ encoded_hv).sum(axis=1)
+    else:
+        score = class_am @ encoded_hv
+
+    predict_idx = np.argmax(score)
+
+    return predict_idx
+
+
 # ---------------------------------------------------------------------------
 # Hypervector generation functions
 # ---------------------------------------------------------------------------
@@ -38,7 +79,7 @@ def hv_gen_empty(hv_dim: int) -> np.ndarray:
     Returns:
         np.ndarray: An empty hypervector of zeros.
     """
-    return np.zeros(hv_dim, dtype=float)
+    return np.zeros(hv_dim)
 
 
 # Generate using random indexing style
@@ -151,7 +192,7 @@ def hv_gen_empty_mem(num_hv: int, hv_dim: int) -> np.ndarray:
     Returns:
         np.ndarray: An empty hypervector memory.
     """
-    return np.zeros((num_hv, hv_dim), dtype=np.int32)
+    return np.zeros((num_hv, hv_dim))
 
 
 # Generating orthogonal item memory
@@ -166,10 +207,10 @@ def hv_gen_orthogonal_im(
     """
     Generate an item memory with orthogonal hypervectors.
 
-    Args:
+    Parameters:
         num_items (int): The number of items in the item memory.
         hv_size (int): The size of each hypervector.
-        type (str): The type of hypervector.
+        hv_type (str): The type of hypervector.
         Can be 'bipolar', 'binary', 'real', or 'complex'.
 
     Returns:
@@ -187,6 +228,47 @@ def hv_gen_orthogonal_im(
             [hv_gen_ri(hv_size, gen_ri_p_dense, hv_type) for _ in range(num_items)]
         )
     return im
+
+
+# Generating continuous item memory
+def hv_gen_continuous_im(
+    num_items=21,
+    hv_size=1024,
+    cim_max_is_ortho=True,
+    hv_type="bipolar",
+):
+    """
+    Generate a continuous item memory (CIM).
+
+    Parameters:
+        num_items (int): The number of items in the CIM.
+        hv_size (int): The size of each hypervector.
+        cim_max_is_ortho (bool): If True, the maximum distance
+                                 between hypervectors is orthogonal.
+        hv_type (str): The type of hypervector. Can be 'bipolar' or 'binary'.
+
+    Returns:
+        np.ndarray: The generated continuous item memory.
+    """
+    # First initialize some seed HV
+    # Calculate % number of flips
+    if cim_max_is_ortho:
+        num_flips = (hv_size // 2) // (num_items - 1)
+    else:
+        num_flips = hv_size // (num_items - 1)
+
+    # Initialize empty matrix
+    cim = hv_gen_empty_mem(num_items, hv_size)
+
+    # Generate first seed HV
+    cim[0] = hv_gen_ri(hv_size, p_dense=0.5, hv_type=hv_type)
+
+    # Iteratively generate other HVs
+    for i in range(num_items - 1):
+        cim[i + 1] = hv_rand_flip(
+            cim[i], i * num_flips, (i + 1) * num_flips, hv_type=hv_type
+        )
+    return cim
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +337,7 @@ def hv_binarize(
 def hv_norm_dist(
     hv_a: np.ndarray,
     hv_b: np.ndarray,
-    hv_type: str = "binary",
+    hv_type: str = "bipolar",
     quant_type: Optional[str] = None,
 ) -> float:
     """
@@ -491,3 +573,23 @@ if __name__ == "__main__":
 
     # Get pair-wise distances between the hypervectors
     checker_im_pairwise_dist(lfsr_set, hv_type=HV_TYPE, threshold=THRESHOLD)
+
+    # ---------------------------
+    # Generating CiM
+    # ---------------------------
+    print("======== CiM Tests ========")
+    HV_TYPE = "bipolar"
+    NUM_ITEMS = 21
+    # Generate a continuous item memory
+    cim_set = hv_gen_continuous_im(
+        num_items=NUM_ITEMS,
+        hv_size=HV_DIM,
+        cim_max_is_ortho=False,
+        hv_type=HV_TYPE,
+    )
+
+    # Get pair-wise distances between the hypervectors
+    cim_distances = profile_im_pairwise_dist(cim_set, hv_type=HV_TYPE)
+    # Just manual inspection to see if it is working
+    print("Pairwise distances of 1st CiM HV:")
+    print(cim_distances[0])

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -1,0 +1,286 @@
+"""
+================================
+VSAX Model Classes and Functions
+================================
+
+This library consists classes and functions for implementing various VSA models.
+These classes are meant to be reproducible and extendable to other applications.
+"""
+
+import vsax
+import vsax_util
+import numpy as np
+from tqdm import tqdm
+from typing import Optional
+
+# ============================================================================-------
+# Main VSA Model class
+# ============================================================================-------
+
+
+class vsaModel:
+    """
+    Base class for VSA models.
+
+    Parameters:
+        hv_size (int): The size of the hypervectors.
+        hv_type (str): The type of hypervector.
+                       Can be 'bipolar', 'binary', 'real', or 'complex'.
+        num_ortho_im (int): The number of orthogonal item memories.
+        num_cim (int): The number of continuous item memories.
+        cim_max_is_ortho (bool): If True, the maximum distance between
+                                 CIM hypervectors is orthogonal.
+        class_list (list): List of class labels.
+        gen_type (str): The type of hypervector generation. Can be 'ri' or 'lfsr'.
+        gen_ri_p_dense (float): The density of the random index hypervectors.
+        gen_lfsr_base_seed (int): The base seed for the LFSR generator.
+    """
+
+    def __init__(
+        self,
+        hv_size: int = 1024,
+        hv_type: str = "bipolar",
+        num_ortho_im: int = 1024,
+        num_cim: int = 21,
+        cim_max_is_ortho: bool = True,
+        class_list: Optional[list] = None,
+        gen_type: str = "ri",
+        gen_ri_p_dense: float = 0.5,
+        gen_lfsr_base_seed: int = 42,
+    ):
+        # Base parameters
+        self.hv_size = hv_size
+        self.hv_type = hv_type
+
+        # Item memory parameters
+        self.num_ortho_im = num_ortho_im
+        self.num_cim = num_cim
+        self.cim_max_is_ortho = cim_max_is_ortho
+        self.gen_type = gen_type
+        self.gen_ri_p_dense = gen_ri_p_dense
+        self.gen_lfsr_base_seed = gen_lfsr_base_seed
+
+        # Parameters that will be determined later
+        self.class_list = class_list
+        self.num_classes = len(class_list)
+
+        # Some extra internal parameters
+        self.binarize_encode = False
+        self.binarize_am = False
+
+        # Generate list of item memories (iMs)
+        self.ortho_im = vsax.hv_gen_orthogonal_im(
+            num_items=self.num_ortho_im,
+            hv_size=self.hv_size,
+            hv_type=self.hv_type,
+            gen_type=self.gen_type,
+            gen_ri_p_dense=self.gen_ri_p_dense,
+            gen_lfsr_base_seed=self.gen_lfsr_base_seed,
+        )
+
+        # Generate list of CiM
+        self.cim = vsax.hv_gen_continuous_im(
+            num_items=self.num_cim,
+            hv_size=self.hv_size,
+            cim_max_is_ortho=self.cim_max_is_ortho,
+            hv_type=self.hv_type,
+        )
+
+        # Initialization of associative memories
+        self.class_am = vsax.hv_gen_empty_mem(self.num_classes, self.hv_size)
+        self.class_am_frozen = vsax.hv_gen_empty_mem(self.num_classes, self.hv_size)
+        self.class_am_bin = vsax.hv_gen_empty_mem(self.num_classes, self.hv_size)
+        self.class_am_count = np.zeros(self.num_classes)
+
+        # Some statistics for testing
+        self.test_class_score = np.zeros(self.num_classes)
+        self.test_class_accuracy = np.zeros(self.num_classes)
+        self.model_accuracy = None
+
+        # Some debugging parameters
+        self.tqdm_train_dbg = True
+        self.tqdm_retrain_dbg = True
+        self.tqdm_test_dbg = True
+
+    # Main encoding function
+    def encode(self, item_data):
+        print(
+            "Empty encoding, please make sure to \
+            override this function in the subclass."
+        )
+
+    # Training function
+    def train_model(self, X_train):
+        """
+        Train the VSA model using the provided training data.
+
+        Parameters:
+            X_train (list): A list of training data for each class.
+        """
+        for class_label in range(self.num_classes):
+            data_len = len(X_train[class_label])
+
+            # Non-binarized training
+            for item_num in tqdm(
+                range(data_len),
+                desc=f"Training class {class_label}",
+                disable=not self.tqdm_train_dbg,
+            ):
+                # Getting encodede HV
+                encoded_vec = self.encode(X_train[class_label][item_num])
+                # Bundle to the appropriate class
+                self.class_am[class_label] += encoded_vec
+
+            # Automatically compute binarized output
+            threshold = data_len / 2
+            self.class_am_bin[class_label] = vsax.hv_binarize(
+                self.class_am[class_label], threshold, self.hv_type
+            )
+
+            # Setting the frozen class
+            self.class_am_frozen[class_label] = np.copy(self.class_am[class_label])
+
+            # Updating class number
+            self.class_am_count[class_label] = data_len
+        print("Training complete!")
+
+    # Testing function
+    def test_model(self, X_test):
+        """
+        Test the VSA model using the provided test data.
+        Parameters:
+            X_test (list): A list of test data for each class.
+        Returns:
+            float: The overall accuracy of the model.
+        """
+        correct_count = 0
+        class_correct_count = 0
+        total_count = 0
+
+        if self.binarize_am:
+            class_am = self.class_am_bin
+        else:
+            class_am = self.class_am_frozen
+
+        for class_label in range(self.num_classes):
+            data_len = len(X_test[class_label])
+            class_correct_count = 0
+            for item_num in tqdm(
+                range(data_len),
+                desc=f"Testing class {class_label}",
+                disable=not self.tqdm_test_dbg,
+            ):
+                # Getting encoded HV
+                encoded_vec = self.encode(X_test[class_label][item_num])
+                # Compare with each class AM
+                predict_label = vsax.hv_prediction_idx(
+                    class_am, encoded_vec, hv_type=self.hv_type
+                )
+
+                if predict_label == class_label:
+                    correct_count += 1
+                    class_correct_count += 1
+                total_count += 1
+
+            self.test_class_score[class_label] = class_correct_count
+            self.test_class_accuracy[class_label] = class_correct_count / data_len
+
+        # Total score
+        accuracy = correct_count / total_count
+        self.model_accuracy = accuracy
+        print("Testing complete!")
+        return accuracy
+
+    # Function to print model statistics
+    def print_model_stats(self):
+        """
+        Print the statistics of the VSA model.
+        """
+
+        print("")
+        print("===================")
+        print(" Model Statistics:")
+        print("===================")
+
+        # Print internal parameters
+        print(f"HV Size: {self.hv_size}")
+        print(f"HV Type: {self.hv_type}")
+        print(f"Number of Orthogonal IMs: {self.num_ortho_im}")
+        print(f"Number of Continuous IMs: {self.num_cim}")
+        print(f"Number of Classes: {self.num_classes}")
+
+        # Print modes
+        print(f"Binarize Encode: {self.binarize_encode}")
+        print(f"Binarize AM: {self.binarize_am}")
+
+        print("===================")
+        print(" Accuracy Statistics:")
+        print("===================")
+        # Printing accuracies
+        for class_label in range(self.num_classes):
+            class_acc = self.test_class_accuracy[class_label]
+            print(f"Class {class_label} Accuracy: {class_acc*100:.2f}%")
+
+        print(f"Overall Accuracy: {self.model_accuracy*100:.2f}%")
+
+
+if __name__ == "__main__":
+    # Simple test on the character recognition application
+    char_recog_dataset = vsax_util.extract_dataset(
+        "../hdc_exp/data_set/char_recog/characters.txt"
+    )
+
+    # Post-process to get list of character inputs
+    # Use this as both train and test inputs
+    char_recog_dict = dict()
+    for i in range(len(char_recog_dataset)):
+        char_recog_dict[i] = [np.array(list(map(int, list(char_recog_dataset[i]))))]
+
+    # Create char encode model
+    class vsaCharModel(vsaModel):
+        def encode(self, item_data):
+            # Feature length
+            item_len = len(item_data)
+            # Threshold
+            threshold = item_len / 2
+            encoded_vec = vsax.hv_gen_empty(self.hv_size)
+            # Iterate per item
+            for i in range(item_len):
+                # If black pixel retain original orthogonal iM,
+                # if white pixel permute orthogonal iM by 1
+                if item_data[i] == 0:
+                    encoded_vec += self.ortho_im[i]
+                else:
+                    encoded_vec += vsax.hv_circ_perm(self.ortho_im[i], 1)
+            # Binarize input data
+            if self.binarize_encode:
+                encoded_vec = vsax.hv_binarize(encoded_vec, threshold, self.hv_type)
+            return encoded_vec
+
+    # Create the model
+    vsa_char_model = vsaCharModel(
+        hv_size=1024,
+        hv_type="bipolar",
+        num_ortho_im=35,
+        num_cim=11,
+        cim_max_is_ortho=True,
+        class_list=list(range(10)),
+        gen_type="ri",
+        gen_ri_p_dense=0.5,
+        gen_lfsr_base_seed=42,
+    )
+
+    # Train the model
+    vsa_char_model.train_model(char_recog_dict)
+
+    # Test the model
+    accuracy = vsa_char_model.test_model(char_recog_dict)
+
+    # Print model statistics
+    vsa_char_model.print_model_stats()
+
+    # Expected output is around 98%
+    if accuracy >= 0.98:
+        print("VSAX Model Pass!")
+    else:
+        raise ValueError("VSAX Model did not achieve expected accuracy.")

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -7,6 +7,7 @@ This library consists classes and functions for implementing various VSA models.
 These classes are meant to be reproducible and extendable to other applications.
 """
 
+import os
 import vsax
 import vsax_util
 import numpy as np
@@ -226,8 +227,9 @@ class vsaModel:
 
 if __name__ == "__main__":
     # Simple test on the character recognition application
+    base_dir = os.path.dirname(os.path.abspath(__file__))
     char_recog_dataset = vsax_util.extract_dataset(
-        "../hdc_exp/data_set/char_recog/characters.txt"
+        os.path.join(base_dir, "../hdc_exp/data_set/char_recog/characters.txt")
     )
 
     # Post-process to get list of character inputs

--- a/lib/vsax_util.py
+++ b/lib/vsax_util.py
@@ -1,0 +1,33 @@
+"""
+================================
+VSAX Utility Functions
+================================
+
+This library consists of utility functions like data downloading and processing.
+Also consists of plotting functions that are useful for profiling too.
+"""
+
+# ---------------------------------------------------------------------------
+# File extraction functions
+# ---------------------------------------------------------------------------
+
+
+# For simple file extraction
+def extract_dataset(file_path):
+    """
+    Extract dataset from a text file.
+    Parameters:
+        file_path (str): The path to the text file containing the dataset.
+    Returns:
+        list: A list of strings, where each string is a line from the file.
+    """
+    # Initialize empty data set array
+    dataset = []
+
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+
+        for line in lines:
+            dataset.append(line.strip())
+
+    return dataset

--- a/pixi.toml
+++ b/pixi.toml
@@ -70,3 +70,4 @@ requests     = ">=2.31"
 [tasks]
 smoke-test = "python -c \"import cocotb, pytest, numpy, matplotlib, mako, jsonref, hjson, ruff, black, flake8, tqdm, requests; print('Environment OK')\" && verilator --version"
 lib-check = "python lib/vsax.py"
+model-check = "python lib/vsax_models.py"


### PR DESCRIPTION
To make sure we can run programs later on, we add the VSA models library as an easier way to create and train models.
Ideally, we just need to change how the data is encoded while keeping all training and testing mechanisms the same.

Included:
- [x] Add of `vsax_models.py`
- [x] Add of `vsax_util.py`
- [x] Add to the pixi and ci list
- [x] Use the simplest character recognition as a CI checker