### PR TITLE
Add multi-input bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,29 @@ jobs:
 
       - name: Run RTL IM check
         run: pixi run rtl-im-check
+
+  rtl-common-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+
+      - name: Run RTL Common check
+        run: pixi run rtl-common-check
+
+  rtl-encoder-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+
+      - name: Run RTL Encoder check
+        run: pixi run rtl-encoder-check

--- a/pixi.toml
+++ b/pixi.toml
@@ -110,6 +110,11 @@ rtl-common-check = """
     tests/test_fifo.py
     """
 
+rtl-encoder-check = """
+    pytest -n $(nproc) --dist=loadfile \
+    tests/test_multi_in_bundler_unit.py
+    """
+
 # ── Docs Tasks ────────────────────────────────────────────────────────────────
 [feature.docs.tasks]
 docs-build = "make -C docs html"

--- a/rtl/encoder/multi_in_bundler_unit.sv
+++ b/rtl/encoder/multi_in_bundler_unit.sv
@@ -1,0 +1,105 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: Multi-In Bundler Unit
+// Description:
+// A multi-input bi-directional bundler unit made with saturating counters.
+//
+// Parameters:
+// - CounterWidth: Bit width of the internal counter (and output)
+// - NumInputs:   Number of input bits to be bundled (each can contribute +1 or -1 to the counter)
+//
+// Inputs and Outputs:
+// - clk_i:       Clock input for the counter register
+// - rst_ni:      Active-low reset for the counter register
+// - clr_i:       Synchronous clear for the counter (resets to zero on next clock edge)
+// - bit_i:       Array of input bits (NumInputs elements) that contribute to the counter
+// - valid_i:     Array of valid signals (NumInputs elements) indicating which input bits are valid for this cycle
+// - counter_o:   Output of the counter (CounterWidth bits wide), which is the bundled result of the input bits
+//---------------------------
+
+module multi_in_bundler_unit #(
+  parameter int unsigned CounterWidth = 8,
+  parameter int unsigned NumInputs = 4,
+)(
+  input  logic                           clk_i,
+  input  logic                           rst_ni,
+  input  logic                           clr_i,
+  input  logic        [   NumInputs-1:0] bit_i,
+  input  logic        [   NumInputs-1:0] valid_i,
+  output logic signed [CounterWidth-1:0] counter_o
+);
+
+  //---------------------------
+  // Internal Parameters
+  //---------------------------
+  localparam int unsigned SmallDataWidth = 2;
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic saturate_low;
+  logic saturate_high;
+  logic signed [CounterWidth-1:0] counter_next;
+  logic signed [CounterWidth-1:0] counter_sum;
+
+  
+
+  logic signed [CounterWidth-1:0] max_val;
+  logic signed [CounterWidth-1:0] min_val;
+
+  // Maximum positive value for signed counter
+  assign max_val = {1'b0, {(CounterWidth-1){1'b1}}}; 
+  // Minimum negative value for signed counter
+  assign min_val = {1'b1, {(CounterWidth-1){1'b0}}}; 
+
+  //---------------------------
+  // Combinational Logic
+  //---------------------------
+
+  // Saturate low happens when counter == 10000...000
+  assign saturate_low  = (counter_o == {1'b1,{(CounterWidth-1){1'b0}}}) ? 1'b1: 1'b0;
+
+  // Saturate high happens when counter == 01111...111
+  assign saturate_high = (counter_o == {1'b0,{(CounterWidth-1){1'b1}}}) ? 1'b1: 1'b0;
+
+  // Counter next state logic
+  always_comb begin
+    // Default: counter_next comes from counter_o
+    counter_next = counter_o;
+    counter_sum  = counter_o;
+
+    // Accumulate contributions from each input with per-step saturation.
+    // Saturation is checked against counter_sum (not counter_o) so that
+    // clamping stays correct across multiple iterations of the loop.
+    for (int i = 0; i < NumInputs; i++) begin
+      if (valid_i[i]) begin
+        if (bit_i[i]) begin
+          // +1: clamp at high saturation bound
+          counter_sum = (counter_sum == $signed({1'b0, {(CounterWidth-1){1'b1}}})) ?
+                        counter_sum : counter_sum + 1;
+        end else begin
+          // -1: clamp at low saturation bound
+          counter_sum = (counter_sum == $signed({1'b1, {(CounterWidth-1){1'b0}}})) ?
+                        counter_sum : counter_sum - 1;
+        end
+      end
+    end
+
+    // Update counter_next if any valid input is high
+    if (|valid_i) begin
+      counter_next = counter_sum;
+    end
+  end
+
+  // Main counter register
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if(!rst_ni) begin
+      counter_o <= {CounterWidth{1'b0}};
+    end else begin
+      counter_o <= counter_next;
+    end
+  end
+
+endmodule

--- a/rtl/encoder/multi_in_bundler_unit.sv
+++ b/rtl/encoder/multi_in_bundler_unit.sv
@@ -21,7 +21,7 @@
 
 module multi_in_bundler_unit #(
   parameter int unsigned CounterWidth = 8,
-  parameter int unsigned NumInputs = 4,
+  parameter int unsigned NumInputs = 4
 )(
   input  logic                           clk_i,
   input  logic                           rst_ni,
@@ -35,65 +35,83 @@ module multi_in_bundler_unit #(
   // Internal Parameters
   //---------------------------
   localparam int unsigned SmallDataWidth = 2;
+  localparam int unsigned OutAdderTreeDataWidth = SmallDataWidth + $clog2(NumInputs);
 
   //---------------------------
-  // Wires
+  // Wires and registers
   //---------------------------
-  logic saturate_low;
-  logic saturate_high;
-  logic signed [CounterWidth-1:0] counter_next;
-  logic signed [CounterWidth-1:0] counter_sum;
+  logic signed [SmallDataWidth-1:0] bit_increment   [NumInputs];
+  logic signed [SmallDataWidth-1:0] valid_increment [NumInputs];
 
-  
+  logic signed [OutAdderTreeDataWidth-1:0] adder_tree;
+  // Counter intermediate value before saturation logic is applied
+  // Therefore we need extra overflow bit
+  logic signed [CounterWidth:0] counter_intermediate;
 
   logic signed [CounterWidth-1:0] max_val;
   logic signed [CounterWidth-1:0] min_val;
 
-  // Maximum positive value for signed counter
-  assign max_val = {1'b0, {(CounterWidth-1){1'b1}}}; 
-  // Minimum negative value for signed counter
-  assign min_val = {1'b1, {(CounterWidth-1){1'b0}}}; 
+  logic any_valid;
+
+  logic signed [CounterWidth-1:0] counter_next;
 
   //---------------------------
-  // Combinational Logic
+  // Combinational logic
   //---------------------------
-
-  // Saturate low happens when counter == 10000...000
-  assign saturate_low  = (counter_o == {1'b1,{(CounterWidth-1){1'b0}}}) ? 1'b1: 1'b0;
-
-  // Saturate high happens when counter == 01111...111
-  assign saturate_high = (counter_o == {1'b0,{(CounterWidth-1){1'b1}}}) ? 1'b1: 1'b0;
-
-  // Counter next state logic
+  // Muxing for selecting appropriate increment/decrement value
   always_comb begin
-    // Default: counter_next comes from counter_o
-    counter_next = counter_o;
-    counter_sum  = counter_o;
-
-    // Accumulate contributions from each input with per-step saturation.
-    // Saturation is checked against counter_sum (not counter_o) so that
-    // clamping stays correct across multiple iterations of the loop.
     for (int i = 0; i < NumInputs; i++) begin
-      if (valid_i[i]) begin
-        if (bit_i[i]) begin
-          // +1: clamp at high saturation bound
-          counter_sum = (counter_sum == $signed({1'b0, {(CounterWidth-1){1'b1}}})) ?
-                        counter_sum : counter_sum + 1;
-        end else begin
-          // -1: clamp at low saturation bound
-          counter_sum = (counter_sum == $signed({1'b1, {(CounterWidth-1){1'b0}}})) ?
-                        counter_sum : counter_sum - 1;
-        end
-      end
+      bit_increment[i] = bit_i[i] ? 1 : -1;
     end
 
-    // Update counter_next if any valid input is high
-    if (|valid_i) begin
-      counter_next = counter_sum;
+    for (int i = 0; i < NumInputs; i++) begin
+      valid_increment[i] = valid_i[i] ? bit_increment[i] : 0;
     end
   end
 
+  // Adder tree instance
+  adder_tree #(
+    .NumInputs          ( NumInputs       ),
+    .InDataWidth        ( SmallDataWidth  )
+  ) i_adder_tree (
+    .data_i             ( valid_increment ),
+    .adder_tree_data_o  ( adder_tree      )
+  );
+
+  // Counter intermediate value is the current counter plus the adder tree output
+  assign counter_intermediate = counter_o + adder_tree;
+
+  // Maximum positive value for signed counter
+  assign max_val = {1'b0, {(CounterWidth-1){1'b1}}};
+  // Minimum negative value for signed counter
+  assign min_val = {1'b1, {(CounterWidth-1){1'b0}}};
+
+  // Check if any input is valid
+  assign any_valid = |valid_i;
+
+  // Check for saturation conditions
+  // This is technically a decoder/mux only
+  always_comb begin
+    if (clr_i) begin
+      counter_next = 0;
+    end else if (any_valid) begin
+      if (counter_intermediate > max_val) begin
+        counter_next = max_val;
+      end else if (counter_intermediate < min_val) begin
+        counter_next = min_val;
+      end else begin
+        // Take the valid bits, ignoring the overflow bit
+        counter_next = counter_intermediate[CounterWidth-1:0];
+      end
+    end else begin
+      // No valid inputs, keep the counter unchanged
+      counter_next = counter_o;
+    end
+  end
+
+  //---------------------------
   // Main counter register
+  //---------------------------
   always_ff @ (posedge clk_i or negedge rst_ni) begin
     if(!rst_ni) begin
       counter_o <= {CounterWidth{1'b0}};

--- a/tests/test_multi_in_bundler_unit.py
+++ b/tests/test_multi_in_bundler_unit.py
@@ -1,0 +1,201 @@
+"""
+Copyright 2024 KU Leuven
+Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+Description:
+This tests the basic functionality of the multi-input bundler unit.
+The idea is that there can be multiple inputs that contribute
+to the same counter, and the bundler unit needs to correctly
+increment or decrement the counter based on the valid and bit inputs.
+"""
+
+from util import setup_and_run
+
+import cocotb
+from cocotb.clock import Clock
+from util import clock_and_time, gen_randint
+import pytest
+
+
+# Local parameters
+COUNTER_WIDTH = 8
+NUM_INPUTS = 4
+
+MAX_VAL = 2 ** (COUNTER_WIDTH - 1) - 1
+MIN_VAL = -(2 ** (COUNTER_WIDTH - 1))
+
+NUM_TESTS = 20
+
+
+# Test functions
+# For clearing bundler unit
+async def clear_bundler(dut):
+    dut.clr_i.value = 1
+    await clock_and_time(dut.clk_i)
+    dut.clr_i.value = 0
+    return
+
+
+# Printing of counter output
+def print_counter_output(dut):
+    cocotb.log.info(f"Counter output: {dut.counter_o.value.signed_integer}")
+    return
+
+
+# Incrementing input
+async def increment_inputs(dut):
+    for i in range(NUM_INPUTS):
+        dut.valid_i[i].value = 1
+        dut.bit_i[i].value = 1
+    await clock_and_time(dut.clk_i)
+    return
+
+
+# Decrementing input
+async def decrement_inputs(dut):
+    for i in range(NUM_INPUTS):
+        dut.valid_i[i].value = 1
+        dut.bit_i[i].value = 0
+    await clock_and_time(dut.clk_i)
+    return
+
+
+# Randomizing inputs
+async def randomize_inputs(dut):
+    valid_set = []
+    bit_set = []
+    for i in range(NUM_INPUTS):
+        valid_set.append(gen_randint(0, 1))
+        bit_set.append(gen_randint(0, 1))
+        dut.valid_i[i].value = valid_set[i]
+        dut.bit_i[i].value = bit_set[i]
+    # Calculate that for valid index
+    # If valid and bit is 1, increment by 1
+    # If valid and bit is 0, decrement by 1
+    total_value = 0
+    for i in range(NUM_INPUTS):
+        if valid_set[i] == 1:
+            if bit_set[i] == 1:
+                total_value += 1
+            else:
+                total_value -= 1
+    await clock_and_time(dut.clk_i)
+    return total_value
+
+
+# Clearing inputs but
+# without time progression
+def clear_inputs_no_clock(dut):
+    for i in range(NUM_INPUTS):
+        dut.bit_i[i].value = 0
+        dut.valid_i[i].value = 0
+    dut.clr_i.value = 0
+
+
+# Test routine
+@cocotb.test()
+async def multi_in_bundler_unit_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("           Testing Bundler Unit             ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize input values
+    clear_inputs_no_clock(dut)
+
+    dut.rst_ni.value = 0
+
+    # Initialize clock always
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Wait one cycle for reset
+    await clock_and_time(dut.clk_i)
+
+    dut.rst_ni.value = 1
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("            Testing Increments              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    for i in range(
+        MAX_VAL // NUM_INPUTS + 5
+    ):  # Test incrementing beyond max value to check saturation
+        await increment_inputs(dut)
+
+    # Check final value is saturated at MAX_VAL
+    assert (
+        dut.counter_o.value.signed_integer == MAX_VAL
+    ), "Counter did not saturate at MAX_VAL as expected"
+
+    # Clear inputs before next test
+    clear_inputs_no_clock(dut)
+    await clear_bundler(dut)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("            Testing Decrements              ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    for i in range(
+        -MIN_VAL // NUM_INPUTS + 5
+    ):  # Test decrementing beyond min value to check saturation
+        await decrement_inputs(dut)
+
+    # Check final value is saturated at MIN_VAL
+    assert (
+        dut.counter_o.value.signed_integer == MIN_VAL
+    ), "Counter did not saturate at MIN_VAL as expected"
+
+    # Clear inputs before next test
+    clear_inputs_no_clock(dut)
+    await clear_bundler(dut)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Testing Randomization             ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    expected_value = 0
+    for i in range(NUM_TESTS):  # Test with 20 random input combinations
+        increment_val = await randomize_inputs(dut)
+        expected_value += increment_val
+
+        # Check for saturation
+        if expected_value > MAX_VAL:
+            expected_value = MAX_VAL
+        elif expected_value < MIN_VAL:
+            expected_value = MIN_VAL
+
+        assert dut.counter_o.value.signed_integer == expected_value, (
+            f"Counter value {dut.counter_o.value.signed_integer} "
+            f"does not match expected {expected_value}"
+        )
+
+    # Wait 5 clock cycles
+    for _ in range(5):
+        await clock_and_time(dut.clk_i)
+
+
+# Config and run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"CounterWidth": str(COUNTER_WIDTH), "NumInputs": str(NUM_INPUTS)},
+    ],
+)
+def test_multi_in_bundler_unit(simulator, parameters, waves):
+    verilog_sources = [
+        "/rtl/common/adder_tree.sv",
+        "/rtl/encoder/multi_in_bundler_unit.sv",
+    ]
+
+    toplevel = "multi_in_bundler_unit"
+
+    module = "test_multi_in_bundler_unit"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/test_multi_in_bundler_unit.py
+++ b/tests/test_multi_in_bundler_unit.py
@@ -44,18 +44,22 @@ def print_counter_output(dut):
 
 # Incrementing input
 async def increment_inputs(dut):
-    for i in range(NUM_INPUTS):
-        dut.valid_i[i].value = 1
-        dut.bit_i[i].value = 1
+    input_increment = [1] * NUM_INPUTS
+    data_in = int("".join(str(b) for b in input_increment), 2)
+    dut.valid_i.value = data_in
+    dut.bit_i.value = data_in
     await clock_and_time(dut.clk_i)
     return
 
 
 # Decrementing input
 async def decrement_inputs(dut):
-    for i in range(NUM_INPUTS):
-        dut.valid_i[i].value = 1
-        dut.bit_i[i].value = 0
+    input_decrement = [0] * NUM_INPUTS
+    data_in = int("".join(str(b) for b in input_decrement), 2)
+    dut.bit_i.value = data_in
+    input_decrement = [1] * NUM_INPUTS
+    data_in = int("".join(str(b) for b in input_decrement), 2)
+    dut.valid_i.value = data_in
     await clock_and_time(dut.clk_i)
     return
 
@@ -67,8 +71,10 @@ async def randomize_inputs(dut):
     for i in range(NUM_INPUTS):
         valid_set.append(gen_randint(0, 1))
         bit_set.append(gen_randint(0, 1))
-        dut.valid_i[i].value = valid_set[i]
-        dut.bit_i[i].value = bit_set[i]
+    valid_in = int("".join(str(b) for b in valid_set), 2)
+    bit_in = int("".join(str(b) for b in bit_set), 2)
+    dut.valid_i.value = valid_in
+    dut.bit_i.value = bit_in
     # Calculate that for valid index
     # If valid and bit is 1, increment by 1
     # If valid and bit is 0, decrement by 1
@@ -86,9 +92,8 @@ async def randomize_inputs(dut):
 # Clearing inputs but
 # without time progression
 def clear_inputs_no_clock(dut):
-    for i in range(NUM_INPUTS):
-        dut.bit_i[i].value = 0
-        dut.valid_i[i].value = 0
+    dut.bit_i.value = 0
+    dut.valid_i.value = 0
     dut.clr_i.value = 0
 
 


### PR DESCRIPTION
This PR adds the multi-input bundler. It is an upgrade from the original unit bundler.
- [x] Add multi-input bundler
- [x] Add appropriate test
- [x] Add to CI

Some other clean-up:
- [x] Expanded CI with other checkers too