### PR TITLE
Add pre-trained models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: VSAX Tests
-on: 
+on:
   pull_request:
   workflow_dispatch:
   push:
@@ -71,3 +71,42 @@ jobs:
 
       - name: Run RTL Encoder check
         run: pixi run rtl-encoder-check
+
+  app-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+
+      - name: Run tests in parallel
+        run: |
+          TASKS=(
+            app-test-vsax-digit-recog
+            app-test-vsax-bin-digit-recog
+          )
+          PIDS=()
+          mkdir -p logs
+
+          for TASK in "${TASKS[@]}"; do
+            pixi run $TASK > logs/$TASK.log 2>&1 &
+            PIDS+=($!)
+          done
+
+          FAILED=0
+          for PID in "${PIDS[@]}"; do
+            wait $PID || FAILED=1
+          done
+
+          if [ "$FAILED" = "1" ]; then exit 1; fi
+
+      - name: Print logs
+        if: always()
+        run: |
+          for LOG in logs/*.log; do
+            echo "=== $LOG ==="
+            cat "$LOG"
+          done

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -1,0 +1,100 @@
+"""
+VSAX Digit Recognition Application
+
+This application demonstrates the use of VSAX
+for digit recognition using the MNIST dataset.
+"""
+
+# Parameters
+import os
+import sys
+
+# Path directories
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+lib_path = curr_dir + "/../lib"
+data_path = curr_dir + "/../data"
+dataset_path = data_path + "/mnist_bin"
+
+# Appending other paths for libraries
+sys.path.append(lib_path)
+
+# Importing VSAX libraries
+import vsax  # noqa: E402
+import vsax_models  # noqa: E402
+import vsax_util  # noqa: E402
+
+save_mode, load_mode, model_name = vsax_models.vsax_general_parser()
+model_dir = curr_dir + f"/../models/{model_name}.npz"
+
+# Downloading and extracting the MNIST dataset
+vsax_util.download_and_extract(
+    url=vsax_util.vsax_data_url_bin_mnist,
+    out_dir=data_path,
+    delete_archive=True,
+)
+
+# Set class list
+class_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+# Read data
+X_data = vsax_util.read_data(class_list, dataset_path)
+
+# Train and test split
+train_test_split = 0.6
+train_valid_split = 0.75
+
+X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
+    X_data=X_data,
+    class_list=class_list,
+    train_test_split=train_test_split,
+    train_valid_split=train_valid_split,
+)
+
+
+# Make class for digit model
+class digitVSA(vsax_models.vsaModel):
+    def encode(self, item_data):
+        # Feature length
+        item_len = len(item_data)
+        # Threshold for binarization
+        threshold = item_len // 2
+        # Encode hypervector
+        encoded_vec = vsax.hv_gen_empty(self.hv_size)
+        for i in range(item_len):
+            if item_data[i] == 0:
+                encoded_vec += self.ortho_im[i]
+            else:
+                encoded_vec += vsax.hv_circ_perm(self.ortho_im[i], 1)
+        # Binarization
+        if self.binarize_encode:
+            encoded_vec = vsax.hv_binarize(encoded_vec, threshold, self.hv_type)
+        return encoded_vec
+
+
+# Make digit class
+digit_model = digitVSA(
+    model_name=model_name,
+    hv_size=1024,
+    class_list=class_list,
+    gen_type="lfsr",
+)
+
+if load_mode:
+    # Load an existing trained model
+    digit_model.load_model(model_dir)
+else:
+    # Train the model
+    digit_model.train_model(X_train_set)
+
+    # Retrain the model
+    digit_model.retrain_model(X_valid_set)
+
+# Test the model
+digit_model.test_model(X_test_set)
+
+# Print some statistics
+digit_model.print_model_stats()
+
+# Save model
+if save_mode:
+    digit_model.save_model(model_dir)

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -112,7 +112,7 @@ digit_model.test_model(X_test_set)
 digit_model.print_model_stats()
 
 # Checker if accuracy is expected
-assert digit_model.test_acc > 0.8, "Test accuracy is lower than expected."
+assert digit_model.model_accuracy > 0.8, "Test accuracy is lower than expected."
 print("✓ Test accuracy passed.")
 
 # Save model

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -33,9 +33,14 @@ import vsax  # noqa: E402
 import vsax_models  # noqa: E402
 import vsax_util  # noqa: E402
 
-save_mode, load_mode = vsax_models.vsax_general_parser()
+(
+    save_mode,
+    load_mode,
+    disable_tqdm,
+) = vsax_models.vsax_general_parser()
 model_file = model_name + f"_d{HV_SIZE}.npz"
 model_dir = model_path + f"/{model_file}"
+
 
 # Download pre-trained model
 if load_mode:
@@ -53,7 +58,7 @@ vsax_util.download_and_extract(
 )
 
 # Read data
-X_data = vsax_util.read_data(CLASS_LIST, dataset_path)
+X_data = vsax_util.read_data(CLASS_LIST, dataset_path, disable_tqdm=disable_tqdm)
 
 # Train and test split
 train_test_split = 0.6
@@ -64,6 +69,7 @@ X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
     class_list=CLASS_LIST,
     train_test_split=train_test_split,
     train_valid_split=train_valid_split,
+    disable_tqdm=disable_tqdm,
 )
 
 
@@ -94,6 +100,11 @@ digit_model = digitVSA(
     class_list=CLASS_LIST,
     gen_type=GEN_TYPE,
 )
+
+# Disabling TQDM debug progress bars
+digit_model.tqdm_train_disable = disable_tqdm
+digit_model.tqdm_retrain_disable = disable_tqdm
+digit_model.tqdm_test_disable = disable_tqdm
 
 if load_mode:
     # Load an existing trained model

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -1,19 +1,29 @@
 """
-VSAX Digit Recognition Application
+VSAX Binary Digit Recognition Application
 
 This application demonstrates the use of VSAX
 for digit recognition using the MNIST dataset.
+This version does the binary ID-level encoding.
+Where we use binary MNIST images.
 """
 
 # Parameters
 import os
 import sys
+from pathlib import Path
+
+# Global parameters
+HV_SIZE = 1024
+CLASS_LIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+GEN_TYPE = "lfsr"
 
 # Path directories
 curr_dir = os.path.dirname(os.path.abspath(__file__))
+model_name = Path(__file__).stem
 lib_path = curr_dir + "/../lib"
 data_path = curr_dir + "/../data"
 dataset_path = data_path + "/mnist_bin"
+model_path = curr_dir + "/../models"
 
 # Appending other paths for libraries
 sys.path.append(lib_path)
@@ -23,8 +33,17 @@ import vsax  # noqa: E402
 import vsax_models  # noqa: E402
 import vsax_util  # noqa: E402
 
-save_mode, load_mode, model_name = vsax_models.vsax_general_parser()
-model_dir = curr_dir + f"/../models/{model_name}.npz"
+save_mode, load_mode = vsax_models.vsax_general_parser()
+model_file = model_name + f"_d{HV_SIZE}.npz"
+model_dir = model_path + f"/{model_file}"
+
+# Download pre-trained model
+if load_mode:
+    vsax_util.download_file(
+        url=f"{vsax_util.git_trained_models_url}/{model_file}",
+        out_dir=model_path,
+        filename=model_file,
+    )
 
 # Downloading and extracting the MNIST dataset
 vsax_util.download_and_extract(
@@ -33,11 +52,8 @@ vsax_util.download_and_extract(
     delete_archive=True,
 )
 
-# Set class list
-class_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-
 # Read data
-X_data = vsax_util.read_data(class_list, dataset_path)
+X_data = vsax_util.read_data(CLASS_LIST, dataset_path)
 
 # Train and test split
 train_test_split = 0.6
@@ -45,7 +61,7 @@ train_valid_split = 0.75
 
 X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
     X_data=X_data,
-    class_list=class_list,
+    class_list=CLASS_LIST,
     train_test_split=train_test_split,
     train_valid_split=train_valid_split,
 )
@@ -74,9 +90,9 @@ class digitVSA(vsax_models.vsaModel):
 # Make digit class
 digit_model = digitVSA(
     model_name=model_name,
-    hv_size=1024,
-    class_list=class_list,
-    gen_type="lfsr",
+    hv_size=HV_SIZE,
+    class_list=CLASS_LIST,
+    gen_type=GEN_TYPE,
 )
 
 if load_mode:

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -111,6 +111,10 @@ digit_model.test_model(X_test_set)
 # Print some statistics
 digit_model.print_model_stats()
 
+# Checker if accuracy is expected
+assert digit_model.test_acc > 0.8, "Test accuracy is lower than expected."
+print("✓ Test accuracy passed.")
+
 # Save model
 if save_mode:
     digit_model.save_model(model_dir)

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -104,6 +104,10 @@ digit_model.test_model(X_test_set)
 # Print some statistics
 digit_model.print_model_stats()
 
+# Checker if accuracy is expected
+assert digit_model.test_acc > 0.8, "Test accuracy is lower than expected."
+print("✓ Test accuracy passed.")
+
 # Save model
 if save_mode:
     digit_model.save_model(model_dir)

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -33,6 +33,7 @@ import vsax_util  # noqa: E402
 (
     save_mode,
     load_mode,
+    disable_tqdm,
 ) = vsax_models.vsax_general_parser()
 model_file = model_name + f"_d{HV_SIZE}.npz"
 model_dir = model_path + f"/{model_file}"
@@ -52,7 +53,7 @@ vsax_util.download_and_extract(
 )
 
 # Read data
-X_data = vsax_util.read_data(CLASS_LIST, dataset_path)
+X_data = vsax_util.read_data(CLASS_LIST, dataset_path, disable_tqdm=disable_tqdm)
 
 # Train and test split
 train_test_split = 0.6
@@ -63,6 +64,7 @@ X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
     class_list=CLASS_LIST,
     train_test_split=train_test_split,
     train_valid_split=train_valid_split,
+    disable_tqdm=disable_tqdm,
 )
 
 
@@ -87,6 +89,11 @@ digit_model = digitVSA(
     hv_size=HV_SIZE,
     class_list=CLASS_LIST,
 )
+
+# Disabling TQDM debug progress bars
+digit_model.tqdm_train_disable = disable_tqdm
+digit_model.tqdm_retrain_disable = disable_tqdm
+digit_model.tqdm_test_disable = disable_tqdm
 
 if load_mode:
     # Load an existing trained model

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -9,12 +9,15 @@ for digit recognition using the MNIST dataset.
 import os
 import sys
 
+# Global parameters
+hv_size = 1024
 
 # Path directories
 curr_dir = os.path.dirname(os.path.abspath(__file__))
 lib_path = curr_dir + "/../lib"
 data_path = curr_dir + "/../data"
 dataset_path = data_path + "/mnist_uint"
+model_path = curr_dir + "/../models"
 
 # Appending other paths for libraries
 sys.path.append(lib_path)
@@ -25,13 +28,21 @@ import vsax_models  # noqa: E402
 import vsax_util  # noqa: E402
 
 save_mode, load_mode, model_name = vsax_models.vsax_general_parser()
-model_dir = curr_dir + f"/../models/{model_name}.npz"
+model_file = model_name + f"_d{hv_size}.npz"
+model_dir = model_path + f"/{model_file}"
+
+# Download pre-trained model
+if load_mode:
+    vsax_util.download_file(
+        url=f"{vsax_util.git_trained_models_url}/{model_file}",
+        out_dir=model_path,
+        filename=model_file,
+    )
 
 # Downloading and extracting the MNIST dataset
 vsax_util.download_and_extract(
     url=vsax_util.vsax_data_url_mnist,
     out_dir=data_path,
-    delete_archive=True,
 )
 
 # Set class list
@@ -70,7 +81,7 @@ class digitVSA(vsax_models.vsaModel):
 # Make digit class
 digit_model = digitVSA(
     model_name=model_name,
-    hv_size=1024,
+    hv_size=hv_size,
     class_list=class_list,
 )
 

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -5,25 +5,27 @@ This application demonstrates the use of VSAX
 for digit recognition using the MNIST dataset.
 """
 
-# Parameters
+# Packages
 import os
 import sys
 
+
 # Path directories
-curr_dir = os.getcwd()
+curr_dir = os.path.dirname(os.path.abspath(__file__))
 lib_path = curr_dir + "/../lib"
-extract_path = curr_dir + "/../data/extract_data"
 data_path = curr_dir + "/../data"
-dir_bin_data = data_path + "/mnist_uint"
+dataset_path = data_path + "/mnist_uint"
 
 # Appending other paths for libraries
 sys.path.append(lib_path)
-sys.path.append(extract_path)
 
 # Importing VSAX libraries
 import vsax  # noqa: E402
 import vsax_models  # noqa: E402
 import vsax_util  # noqa: E402
+
+save_mode, load_mode, model_name = vsax_models.vsax_general_parser()
+model_dir = curr_dir + f"/../models/{model_name}.npz"
 
 # Downloading and extracting the MNIST dataset
 vsax_util.download_and_extract(
@@ -36,17 +38,17 @@ vsax_util.download_and_extract(
 class_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 # Read data
-X_data = vsax_util.read_data(class_list, dir_bin_data)
+X_data = vsax_util.read_data(class_list, dataset_path)
 
 # Train and test split
 train_test_split = 0.6
 train_valid_split = 0.75
 
-X_train_set, X_test_set = vsax_util.split_data(
-    X_data, class_list, split_percent=train_test_split
-)
-X_train_set_src, X_valid_set = vsax_util.split_data(
-    X_train_set, class_list, split_percent=train_valid_split
+X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
+    X_data=X_data,
+    class_list=class_list,
+    train_test_split=train_test_split,
+    train_valid_split=train_valid_split,
 )
 
 
@@ -67,18 +69,27 @@ class digitVSA(vsax_models.vsaModel):
 
 # Make digit class
 digit_model = digitVSA(
+    model_name=model_name,
     hv_size=1024,
     class_list=class_list,
 )
 
-# Train the model
-digit_model.train_model(X_train_set_src)
+if load_mode:
+    # Load an existing trained model
+    digit_model.load_model(model_dir)
+else:
+    # Train the model
+    digit_model.train_model(X_train_set)
 
-# Retrain the model
-digit_model.retrain_model(X_valid_set)
+    # Retrain the model
+    digit_model.retrain_model(X_valid_set)
 
 # Test the model
 digit_model.test_model(X_test_set)
 
 # Print some statistics
 digit_model.print_model_stats()
+
+# Save model
+if save_mode:
+    digit_model.save_model(model_dir)

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -105,7 +105,7 @@ digit_model.test_model(X_test_set)
 digit_model.print_model_stats()
 
 # Checker if accuracy is expected
-assert digit_model.test_acc > 0.8, "Test accuracy is lower than expected."
+assert digit_model.model_accuracy > 0.8, "Test accuracy is lower than expected."
 print("✓ Test accuracy passed.")
 
 # Save model

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -8,9 +8,11 @@ for digit recognition using the MNIST dataset.
 # Packages
 import os
 import sys
+from pathlib import Path
 
 # Global parameters
-hv_size = 1024
+HV_SIZE = 1024
+CLASS_LIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 # Path directories
 curr_dir = os.path.dirname(os.path.abspath(__file__))
@@ -18,6 +20,7 @@ lib_path = curr_dir + "/../lib"
 data_path = curr_dir + "/../data"
 dataset_path = data_path + "/mnist_uint"
 model_path = curr_dir + "/../models"
+model_name = Path(__file__).stem
 
 # Appending other paths for libraries
 sys.path.append(lib_path)
@@ -27,8 +30,11 @@ import vsax  # noqa: E402
 import vsax_models  # noqa: E402
 import vsax_util  # noqa: E402
 
-save_mode, load_mode, model_name = vsax_models.vsax_general_parser()
-model_file = model_name + f"_d{hv_size}.npz"
+(
+    save_mode,
+    load_mode,
+) = vsax_models.vsax_general_parser()
+model_file = model_name + f"_d{HV_SIZE}.npz"
 model_dir = model_path + f"/{model_file}"
 
 # Download pre-trained model
@@ -45,11 +51,8 @@ vsax_util.download_and_extract(
     out_dir=data_path,
 )
 
-# Set class list
-class_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-
 # Read data
-X_data = vsax_util.read_data(class_list, dataset_path)
+X_data = vsax_util.read_data(CLASS_LIST, dataset_path)
 
 # Train and test split
 train_test_split = 0.6
@@ -57,7 +60,7 @@ train_valid_split = 0.75
 
 X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
     X_data=X_data,
-    class_list=class_list,
+    class_list=CLASS_LIST,
     train_test_split=train_test_split,
     train_valid_split=train_valid_split,
 )
@@ -81,8 +84,8 @@ class digitVSA(vsax_models.vsaModel):
 # Make digit class
 digit_model = digitVSA(
     model_name=model_name,
-    hv_size=hv_size,
-    class_list=class_list,
+    hv_size=HV_SIZE,
+    class_list=CLASS_LIST,
 )
 
 if load_mode:

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -13,10 +13,36 @@ import vsax_util
 import numpy as np
 from tqdm import tqdm
 from typing import Optional
+import argparse
 
-# ============================================================================-------
+# ============================================================================
+# General Model Functions
+# ============================================================================
+
+
+# For general parsing
+def vsax_general_parser():
+    parser = argparse.ArgumentParser(description="VSAX Model Training and Testing")
+
+    parser.add_argument(
+        "--save", "-s", action="store_true", help="Train and save the model"
+    )
+    parser.add_argument("--load", "-l", action="store_true", help="Load the model")
+    parser.add_argument(
+        "--model", "-m", type=str, help="Name of model to save/load", default="vsaModel"
+    )
+
+    args = parser.parse_args()
+
+    save_mode = args.save
+    load_mode = args.load
+    model_name = args.model
+    return save_mode, load_mode, model_name
+
+
+# ============================================================================
 # Main VSA Model class
-# ============================================================================-------
+# ============================================================================
 
 
 class vsaModel:
@@ -24,6 +50,7 @@ class vsaModel:
     Base class for VSA models.
 
     Parameters:
+        model_name (str): The name of the model.
         hv_size (int): The size of the hypervectors.
         hv_type (str): The type of hypervector.
                        Can be 'bipolar', 'binary', 'real', or 'complex'.
@@ -35,10 +62,36 @@ class vsaModel:
         gen_type (str): The type of hypervector generation. Can be 'ri' or 'lfsr'.
         gen_ri_p_dense (float): The density of the random index hypervectors.
         gen_lfsr_base_seed (int): The base seed for the LFSR generator.
+
+    Attributes:
+        ortho_im (np.ndarray): The orthogonal item memory hypervectors.
+        cim (np.ndarray): The continuous item memory hypervectors.
+        class_am (np.ndarray): The AM for each class.
+        class_am_frozen (np.ndarray): The frozen AM for each class.
+        class_am_bin (np.ndarray): The binarized AM for each class.
+        class_am_count (np.ndarray): The count of items in each class AM.
+        test_class_score (np.ndarray): The score for each class during testing.
+        test_class_accuracy (np.ndarray): The accuracy for each class during testing.
+        model_accuracy (float): The overall accuracy of the model during testing.
+
+    Debugging Parameters:
+        tqdm_train_dbg (bool): If True, show progress bar during training.
+        tqdm_retrain_dbg (bool): If True, show progress bar during retraining.
+        tqdm_test_dbg (bool): If True, show progress bar during testing.
+
+    Methods:
+        encode(item_data): Encode the input data into a hypervector.
+        train_model(X_train): Train the VSA model using the provided training data.
+        retrain_model(X_train): Retrain the VSA model using the provided training data.
+        test_model(X_test): Test the VSA model using the provided test data.
+        print_model_stats(): Print the statistics of the VSA model.
+        save_model(save_path): Save the model parameters to a file.
+        load_model(load_path): Load the model parameters from a file.
     """
 
     def __init__(
         self,
+        model_name: str = "vsaModel",
         hv_size: int = 1024,
         hv_type: str = "bipolar",
         num_ortho_im: int = 1024,
@@ -49,6 +102,9 @@ class vsaModel:
         gen_ri_p_dense: float = 0.5,
         gen_lfsr_base_seed: int = 42,
     ):
+        # Model name
+        self.model_name = model_name
+
         # Base parameters
         self.hv_size = hv_size
         self.hv_type = hv_type
@@ -128,7 +184,7 @@ class vsaModel:
         Parameters:
             X_train (list): A list of training data for each class.
         Returns:
-            Updates the associative memory of the model based on the training data.
+            Updates the AM of the model based on the training data.
         """
         for class_label in range(self.num_classes):
             data_len = len(X_train[class_label])
@@ -270,11 +326,17 @@ class vsaModel:
         print("===================")
 
         # Print internal parameters
+        print(f"Model Name: {self.model_name}")
         print(f"HV Size: {self.hv_size}")
         print(f"HV Type: {self.hv_type}")
         print(f"Number of Orthogonal IMs: {self.num_ortho_im}")
         print(f"Number of Continuous IMs: {self.num_cim}")
         print(f"Number of Classes: {self.num_classes}")
+        print(f"Generation Type: {self.gen_type}")
+        if self.gen_type == "ri":
+            print(f"RI p_dense: {self.gen_ri_p_dense}")
+        elif self.gen_type == "lfsr":
+            print(f"LFSR Base Seed: {self.gen_lfsr_base_seed}")
 
         # Print modes
         print(f"Binarize Encode: {self.binarize_encode}")
@@ -289,6 +351,62 @@ class vsaModel:
             print(f"Class {class_label} Accuracy: {class_acc*100:.2f}%")
 
         print(f"Overall Accuracy: {self.model_accuracy*100:.2f}%")
+
+    # Function to save the model parameters
+    def save_model(self, save_path):
+        """
+        Save the model parameters to a file.
+
+        Parameters:
+            save_path (str): The path to save the model parameters.
+        """
+        np.savez(
+            save_path,
+            model_name=self.model_name,
+            hv_size=self.hv_size,
+            hv_type=self.hv_type,
+            num_ortho_im=self.num_ortho_im,
+            num_cim=self.num_cim,
+            cim_max_is_ortho=self.cim_max_is_ortho,
+            class_list=self.class_list,
+            gen_type=self.gen_type,
+            gen_ri_p_dense=self.gen_ri_p_dense,
+            gen_lfsr_base_seed=self.gen_lfsr_base_seed,
+            ortho_im=self.ortho_im,
+            cim=self.cim,
+            class_am=self.class_am,
+            class_am_frozen=self.class_am_frozen,
+            class_am_bin=self.class_am_bin,
+            class_am_count=self.class_am_count,
+        )
+        print(f"Saved model: {save_path}!")
+
+    # Function to load the model parameters
+    def load_model(self, load_path):
+        """
+        Load the model parameters from a file.
+
+        Parameters:
+            load_path (str): The path to load the model parameters from.
+        """
+        data = np.load(load_path, allow_pickle=True)
+        self.model_name = data["model_name"].item()
+        self.hv_size = data["hv_size"].item()
+        self.hv_type = data["hv_type"].item()
+        self.num_ortho_im = data["num_ortho_im"].item()
+        self.num_cim = data["num_cim"].item()
+        self.cim_max_is_ortho = data["cim_max_is_ortho"].item()
+        self.class_list = data["class_list"].tolist()
+        self.gen_type = data["gen_type"].item()
+        self.gen_ri_p_dense = data["gen_ri_p_dense"].item()
+        self.gen_lfsr_base_seed = data["gen_lfsr_base_seed"].item()
+        self.ortho_im = data["ortho_im"]
+        self.cim = data["cim"]
+        self.class_am = data["class_am"]
+        self.class_am_frozen = data["class_am_frozen"]
+        self.class_am_bin = data["class_am_bin"]
+        self.class_am_count = data["class_am_count"]
+        print(f"Loaded model: {load_path}!")
 
 
 if __name__ == "__main__":

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -28,12 +28,16 @@ def vsax_general_parser():
         "--save", "-s", action="store_true", help="Train and save the model"
     )
     parser.add_argument("--load", "-l", action="store_true", help="Load the model")
+    parser.add_argument(
+        "--dtqdm", "-d", action="store_true", help="Disable tqdm progress bars"
+    )
     args = parser.parse_args()
 
     save_mode = args.save
     load_mode = args.load
+    disable_tqdm = args.dtqdm
 
-    return save_mode, load_mode
+    return save_mode, load_mode, disable_tqdm
 
 
 # ============================================================================
@@ -71,9 +75,9 @@ class vsaModel:
         model_accuracy (float): The overall accuracy of the model during testing.
 
     Debugging Parameters:
-        tqdm_train_dbg (bool): If True, show progress bar during training.
-        tqdm_retrain_dbg (bool): If True, show progress bar during retraining.
-        tqdm_test_dbg (bool): If True, show progress bar during testing.
+        tqdm_train_disable (bool): If True, show progress bar during training.
+        tqdm_retrain_disable (bool): If True, show progress bar during retraining.
+        tqdm_test_disable (bool): If True, show progress bar during testing.
 
     Methods:
         encode(item_data): Encode the input data into a hypervector.
@@ -151,9 +155,9 @@ class vsaModel:
         self.model_accuracy = None
 
         # Some debugging parameters
-        self.tqdm_train_dbg = True
-        self.tqdm_retrain_dbg = True
-        self.tqdm_test_dbg = True
+        self.tqdm_train_disable = False
+        self.tqdm_retrain_disable = False
+        self.tqdm_test_disable = False
 
     # Main encoding function
     def encode(self, item_data):
@@ -182,6 +186,7 @@ class vsaModel:
         Returns:
             Updates the AM of the model based on the training data.
         """
+        print("Training model...")
         for class_label in range(self.num_classes):
             data_len = len(X_train[class_label])
 
@@ -189,7 +194,7 @@ class vsaModel:
             for item_num in tqdm(
                 range(data_len),
                 desc=f"Training class {class_label}",
-                disable=not self.tqdm_train_dbg,
+                disable=self.tqdm_train_disable,
             ):
                 # Getting encodede HV
                 encoded_vec = self.encode(X_train[class_label][item_num])
@@ -211,6 +216,7 @@ class vsaModel:
 
     # Retraining function
     def retrain_model(self, X_train):
+        print("Retraining model...")
         """
         Retrain the VSA model using the provided training data.
 
@@ -230,7 +236,7 @@ class vsaModel:
             for item_num in tqdm(
                 range(data_len),
                 desc=f"Retraining class {class_label}",
-                disable=not self.tqdm_retrain_dbg,
+                disable=self.tqdm_retrain_disable,
             ):
                 # Getting encoded HV
                 encoded_vec = self.encode(X_train[class_label][item_num])
@@ -272,6 +278,8 @@ class vsaModel:
         Returns:
             float: The overall accuracy of the model.
         """
+        print("Testing model...")
+
         correct_count = 0
         class_correct_count = 0
         total_count = 0
@@ -287,7 +295,7 @@ class vsaModel:
             for item_num in tqdm(
                 range(data_len),
                 desc=f"Testing class {class_label}",
-                disable=not self.tqdm_test_dbg,
+                disable=self.tqdm_test_disable,
             ):
                 # Getting encoded HV
                 encoded_vec = self.encode(X_test[class_label][item_num])

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -28,16 +28,12 @@ def vsax_general_parser():
         "--save", "-s", action="store_true", help="Train and save the model"
     )
     parser.add_argument("--load", "-l", action="store_true", help="Load the model")
-    parser.add_argument(
-        "--model", "-m", type=str, help="Name of model to save/load", default="vsaModel"
-    )
-
     args = parser.parse_args()
 
     save_mode = args.save
     load_mode = args.load
-    model_name = args.model
-    return save_mode, load_mode, model_name
+
+    return save_mode, load_mode
 
 
 # ============================================================================

--- a/lib/vsax_models.py
+++ b/lib/vsax_models.py
@@ -360,7 +360,7 @@ class vsaModel:
         Parameters:
             save_path (str): The path to save the model parameters.
         """
-        np.savez(
+        np.savez_compressed(
             save_path,
             model_name=self.model_name,
             hv_size=self.hv_size,

--- a/lib/vsax_util.py
+++ b/lib/vsax_util.py
@@ -157,18 +157,19 @@ def load_dataset(file_path: str) -> np.ndarray:
 
 
 # Reading of data from files for each class label
-def read_data(class_list: list, data_path: str) -> list:
+def read_data(class_list: list, data_path: str, disable_tqdm: bool = False) -> list:
     """
     Read data from files for each class label.
 
     Args:
         class_list: list of class labels
         data_path: path to the data files
+        disable_tqdm: whether to disable tqdm progress bars
     Returns:
         X_data: list of NumPy arrays with data for each class label
     """
     X_data = []
-    for class_label in tqdm(class_list, desc="Reading data"):
+    for class_label in tqdm(class_list, desc="Reading data", disable=disable_tqdm):
         # Training dataset
         read_file = f"{data_path}/{class_label}.txt"
         X_data.append(load_dataset(read_file))
@@ -177,7 +178,10 @@ def read_data(class_list: list, data_path: str) -> list:
 
 # Splitting the data and randomizing items
 def split_data(
-    X_data: list, class_list: list, split_percent: float = 0.8
+    X_data: list,
+    class_list: list,
+    split_percent: float = 0.8,
+    disable_tqdm: bool = False,
 ) -> tuple[list, list]:
     """
     Split data into two parts based on split_percent.
@@ -194,7 +198,7 @@ def split_data(
     X_split_data1 = []
     X_split_data2 = []
 
-    for class_label in tqdm(class_list, desc="Splitting data"):
+    for class_label in tqdm(class_list, desc="Splitting data", disable=disable_tqdm):
         # Get item counts first
         item_len = len(X_data[class_label])
         split1_len = round(item_len * split_percent)
@@ -226,6 +230,7 @@ def split_train_valid_test_set(
     class_list: list,
     train_test_split: float = 0.6,
     train_valid_split: float = 0.75,
+    disable_tqdm: bool = False,
 ) -> tuple[list, list, list]:
     """
     Split data into training, validation, and test sets.
@@ -243,9 +248,12 @@ def split_train_valid_test_set(
         X_test_set: test set
     """
     X_train_set, X_test_set = split_data(
-        X_data, class_list, split_percent=train_test_split
+        X_data, class_list, split_percent=train_test_split, disable_tqdm=disable_tqdm
     )
     X_train_set, X_valid_set = split_data(
-        X_train_set, class_list, split_percent=train_valid_split
+        X_train_set,
+        class_list,
+        split_percent=train_valid_split,
+        disable_tqdm=disable_tqdm,
     )
     return X_train_set, X_valid_set, X_test_set

--- a/lib/vsax_util.py
+++ b/lib/vsax_util.py
@@ -20,6 +20,7 @@ from pathlib import Path
 # List of data sets
 # ---------------------------------------------------------------------------
 vsax_data_url_mnist = "https://github.com/rgantonio/chronomatica/releases/download/mnist_dataset_v1.0/chronomatica_mnist_uint.tar.gz"
+vsax_data_url_bin_mnist = "https://github.com/rgantonio/chronomatica/releases/download/mnist_dataset_v1.0/chronomatica_mnist_bin.tar.gz"
 
 # ---------------------------------------------------------------------------
 # File extraction functions
@@ -142,6 +143,7 @@ def read_data(class_list: list, data_path: str) -> list:
     return X_data
 
 
+# Splitting the data and randomizing items
 def split_data(
     X_data: list, class_list: list, split_percent: float = 0.8
 ) -> tuple[list, list]:
@@ -184,3 +186,34 @@ def split_data(
         X_split_data2.append(split2_list)
 
     return X_split_data1, X_split_data2
+
+
+# Splitting the data but in train, valid, and test sets
+def split_train_valid_test_set(
+    X_data: list,
+    class_list: list,
+    train_test_split: float = 0.6,
+    train_valid_split: float = 0.75,
+) -> tuple[list, list, list]:
+    """
+    Split data into training, validation, and test sets.
+
+    Args:
+        X_data: list of NumPy arrays with data for each class label
+        class_list: list of class labels
+        train_test_split: percentage of data to go into
+        training set (rest goes to test set)
+        train_valid_split: percentage of training set to
+        go into training set (rest goes to validation set)
+    Returns:
+        X_train_set: training set
+        X_valid_set: validation set
+        X_test_set: test set
+    """
+    X_train_set, X_test_set = split_data(
+        X_data, class_list, split_percent=train_test_split
+    )
+    X_train_set, X_valid_set = split_data(
+        X_train_set, class_list, split_percent=train_valid_split
+    )
+    return X_train_set, X_valid_set, X_test_set

--- a/lib/vsax_util.py
+++ b/lib/vsax_util.py
@@ -23,6 +23,12 @@ vsax_data_url_mnist = "https://github.com/rgantonio/chronomatica/releases/downlo
 vsax_data_url_bin_mnist = "https://github.com/rgantonio/chronomatica/releases/download/mnist_dataset_v1.0/chronomatica_mnist_bin.tar.gz"
 
 # ---------------------------------------------------------------------------
+# Main pre-trained model url
+# ---------------------------------------------------------------------------
+ver_trained_models = "v0.1.0"
+git_trained_models_url = f"https://github.com/KULeuven-MICAS/hypercorex/releases/download/vsax_trained_models_{ver_trained_models}"
+
+# ---------------------------------------------------------------------------
 # File extraction functions
 # ---------------------------------------------------------------------------
 
@@ -47,6 +53,32 @@ def extract_dataset(file_path: str) -> list[str]:
             dataset.append(line.strip())
 
     return dataset
+
+
+# For downloading only
+def download_file(url: str, out_dir: str | Path = "data", filename: str | None = None):
+    """
+    Download a file from a URL.
+
+    Args:
+        url (str): The URL to download the file from.
+        out_dir (str | Path): The directory to save the downloaded file in.
+        filename (str | None): Optional override for downloaded filename.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if filename is None:
+        filename = url.split("/")[-1]
+
+    file_path = out_dir / filename
+
+    # Download (skip if already exists)
+    if not file_path.exists():
+        print(f"Downloading {filename}...")
+        urllib.request.urlretrieve(url, file_path)
+    else:
+        print(f"{filename} already exists, skipping download.")
 
 
 # For downloading and extracting archives

--- a/pixi.toml
+++ b/pixi.toml
@@ -115,8 +115,8 @@ rtl-encoder-check = """
     tests/test_multi_in_bundler_unit.py
     """
 # ── App Test Tasks─────────────────────────────────────────────────────────────
-app-test-vsax-digit-recog = "python app/vsax_digit_recog.py -l"
-app-test-vsax-bin-digit-recog = "python app/vsax_bin_digit_recog.py -l"
+app-test-vsax-digit-recog = "python app/vsax_digit_recog.py --load --dtqdm"
+app-test-vsax-bin-digit-recog = "python app/vsax_bin_digit_recog.py --load --dtqdm"
 
 # ── Docs Tasks ────────────────────────────────────────────────────────────────
 [feature.docs.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -114,6 +114,9 @@ rtl-encoder-check = """
     pytest -n $(nproc) --dist=loadfile \
     tests/test_multi_in_bundler_unit.py
     """
+# ── App Test Tasks─────────────────────────────────────────────────────────────
+app-test-vsax-digit-recog = "python app/vsax_digit_recog.py -l"
+app-test-vsax-bin-digit-recog = "python app/vsax_bin_digit_recog.py -l"
 
 # ── Docs Tasks ────────────────────────────────────────────────────────────────
 [feature.docs.tasks]


### PR DESCRIPTION
This PR adds pre-trained models and functions that allow us to load those pre-trained models.
The catch, however, is that we need to save the pre-trained models as releases. Ideally, these models won't be touched so often.
This is meant for easy replication, of course.

Modifications:
- [x] Add load and save mechanics in the vsax models.
- [x] Add URL data set lists.
- [x] Modified the application programs to have a cleaner view.
- [x] Add arg parsers to indicate to load or save and manually train the models.

Additional:
- [x] Add binary MNIST test.
- [x] Updated the tran-valid-test split.
- [x] Add new `.npz` model releases.
- [x] Add CI parallel run checker.