### PR TITLE
Add ID-level encoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           filters: |
             rtl:
               - 'rtl/**'
+              - 'tests/**'
             app:
               - 'app/**'
               - 'lib/**'

--- a/pixi.toml
+++ b/pixi.toml
@@ -113,7 +113,8 @@ rtl-common-check = """
 rtl-encoder-check = """
     pytest -n $(nproc) --dist=loadfile \
     tests/test_multi_in_bundler_unit.py \
-    tests/test_multi_in_bundler_set.py
+    tests/test_multi_in_bundler_set.py \
+    tests/test_id_level_encoder.py 
     """
 # ── App Test Tasks─────────────────────────────────────────────────────────────
 app-test-vsax-digit-recog = "python app/vsax_digit_recog.py --load --dtqdm"

--- a/rtl/encoder/id_level_encoder.sv
+++ b/rtl/encoder/id_level_encoder.sv
@@ -1,0 +1,83 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: ID-level encoder
+// Description:
+// This is a hardwired encoder that does the
+// ID-level encoding for the input tokens.
+// ID-level is simply an equivalent of a MAC
+// but since we dill with binary vectors it's
+// an XOR operation that is combined per bit.
+// In this module, we support multi-input as well.
+//
+// Parameters:
+// - HVDimension: The dimensionality of the hypervectors
+// - NumInputs: The number of input tokens to encode
+// - CounterWidth: The width of the counter for the spatial bundler
+//
+// Inputs and Outputs:
+// - clk_i: Clock input
+// - rst_ni: Active-low reset input
+// - clr_i: Clear signal for the spatial bundler
+// - valid_i: Valid signals for each input token
+// - hv_id_i: Hypervector IDs for each input token
+// - hv_level_i: Hypervector levels for each input token
+// - hv_encoded_o: The encoded hypervectors for each dimension
+// - hv_bin_encoded_o: The binarized encoded hypervector
+//---------------------------
+
+module id_level_encoder #(
+  parameter int unsigned HVDimension  = 512,
+  parameter int unsigned NumInputs    = 4,
+  parameter int unsigned CounterWidth = 8
+)(
+  // Clocks and reset
+  input  logic                           clk_i,
+  input  logic                           rst_ni,
+  // Other input logic
+  input  logic                           clr_i,
+  // Inputs
+  input  logic        [   NumInputs-1:0] valid_i,
+  input  logic        [ HVDimension-1:0] hv_id_i          [NumInputs],
+  input  logic        [ HVDimension-1:0] hv_level_i       [NumInputs],
+  // Outputs
+  output logic signed [CounterWidth-1:0] hv_encoded_o     [HVDimension],
+  output logic        [ HVDimension-1:0] hv_bin_encoded_o
+);
+
+  //---------------------------
+  // Wires
+  //---------------------------
+  logic [HVDimension-1:0] hv_xored [NumInputs];
+
+  //---------------------------
+  // ID-level encoding logic
+  //---------------------------
+  // Simply an XOR array
+  always_comb begin: comb_xor_array
+    for (int i = 0; i < NumInputs; i++) begin
+      for (int j = 0; j < HVDimension; j++) begin
+        hv_xored[i][j] = hv_id_i[i][j] ^ hv_level_i[i][j];
+      end
+    end
+  end
+
+  //---------------------------
+  // Spatial bundler
+  //---------------------------
+  multi_in_bundler_set #(
+    .HVDimension    ( HVDimension      ),
+    .NumInputs      ( NumInputs        ),
+    .CounterWidth   ( CounterWidth     )
+  ) i_multi_in_bundler_set (
+    .clk_i          ( clk_i            ),
+    .rst_ni         ( rst_ni           ),
+    .clr_i          ( clr_i            ),
+    .hv_i           ( hv_xored         ),
+    .valid_i        ( valid_i          ),
+    .counter_o      ( hv_encoded_o     ),
+    .binarized_hv_o ( hv_bin_encoded_o )
+  );
+
+endmodule

--- a/tests/test_id_level_encoder.py
+++ b/tests/test_id_level_encoder.py
@@ -1,0 +1,169 @@
+"""
+Copyright 2024 KU Leuven
+Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+Description:
+This test verifies the functionality of the ID-level encoder.
+Although it is a fixed design, it is sufficient to simulate the encoding function.
+"""
+
+from util import setup_and_run, clock_and_time
+
+import cocotb
+from cocotb.clock import Clock
+import pytest
+import numpy as np
+import os
+import sys
+
+# Importing main lib library
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+lib_path = curr_dir + "/../lib"
+
+sys.path.append(lib_path)
+
+# Importing VSAX libraries
+import vsax  # noqa: E402
+
+# Global parameters
+HV_DIMENSION = 8
+COUNTER_WIDTH = 8
+NUM_INPUTS = 4
+HV_TYPE = "binary"
+NUM_ITEMS = 100
+
+BASE_SEED1 = 42
+BASE_SEED2 = 143
+
+NUM_TESTS = 20
+
+# Generate a set of random hypervectors
+id_set = vsax.hv_gen_orthogonal_im(
+    num_items=NUM_ITEMS,
+    hv_size=HV_DIMENSION,
+    hv_type=HV_TYPE,
+    gen_lfsr_base_seed=BASE_SEED1,
+)
+
+level_set = vsax.hv_gen_orthogonal_im(
+    num_items=NUM_ITEMS,
+    hv_size=HV_DIMENSION,
+    hv_type=HV_TYPE,
+    gen_lfsr_base_seed=BASE_SEED2,
+)
+
+
+def hv_to_int(hv: np.ndarray) -> int:
+    """Convert a binary hypervector (1D numpy array of 0s/1s) to an integer."""
+    return int(np.packbits(hv, bitorder="little").tobytes().hex(), 16)
+
+
+# Load input HVs of num inputs size
+async def load_inputs(dut):
+    # Make list of random indices
+    id_indices = np.random.choice(NUM_ITEMS, NUM_INPUTS, replace=False)
+    level_indices = np.random.choice(NUM_ITEMS, NUM_INPUTS, replace=False)
+    bundled_hv = vsax.hv_gen_empty(HV_DIMENSION)
+    for i in range(NUM_INPUTS):
+        # Load vectors
+        id_hv = id_set[id_indices[i]]
+        level_hv = level_set[level_indices[i]]
+        dut.hv_id_i[i].value = hv_to_int(id_hv)
+        dut.hv_level_i[i].value = hv_to_int(level_hv)
+        # Get XOR of them as expected output
+        xor_hv = vsax.hv_bind(id_hv, level_hv)
+        # Convert back to bipolar
+        bundled_hv += xor_hv * 2 - 1
+    dut.valid_i.value = (1 << NUM_INPUTS) - 1
+    await clock_and_time(dut.clk_i)
+    dut.valid_i.value = 0
+    return bundled_hv
+
+
+async def clear_bundler(dut):
+    dut.clr_i.value = 1
+    await clock_and_time(dut.clk_i)
+    dut.clr_i.value = 0
+
+
+def clear_inputs_no_clock(dut):
+    for i in range(NUM_INPUTS):
+        dut.hv_id_i[i].value = 0
+        dut.hv_level_i[i].value = 0
+    dut.valid_i.value = 0
+    dut.clr_i.value = 0
+
+
+@cocotb.test()
+async def id_level_encoder_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         Testing ID-Level Encoder           ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    await clock_and_time(dut.clk_i)
+    dut.rst_ni.value = 1
+
+    # Iterate through a number of tests
+    for i in range(NUM_TESTS):
+        # Randomized number of loads
+        num_loads = np.random.randint(1, NUM_ITEMS + 1)
+        print(f"Test {i+1}/{NUM_TESTS}: Loading {num_loads} input sets...")
+
+        # Accumulate expected bundled HV over all loads
+        expected_bundled_hv = vsax.hv_gen_empty(HV_DIMENSION)
+        for _ in range(num_loads):
+            expected_bundled_hv += await load_inputs(dut)
+
+        # Read actual bundled HV from DUT output
+        actual_bundled_hv = np.array(
+            [dut.hv_encoded_o[j].value.signed_integer for j in range(HV_DIMENSION)]
+        )
+
+        # Compare expected and actual bundled hypervectors
+        assert np.array_equal(
+            expected_bundled_hv, actual_bundled_hv
+        ), f"Expected: {expected_bundled_hv}, Actual: {actual_bundled_hv}"
+
+        # Clear bundler first before next test
+        await clear_bundler(dut)
+
+    for _ in range(5):
+        await clock_and_time(dut.clk_i)
+
+
+# Config and run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "HVDimension": str(HV_DIMENSION),
+            "NumInputs": str(NUM_INPUTS),
+            "CounterWidth": str(COUNTER_WIDTH),
+        },
+    ],
+)
+def test_id_level_encoder(simulator, parameters, waves):
+    verilog_sources = [
+        "/rtl/common/adder_tree.sv",
+        "/rtl/encoder/multi_in_bundler_unit.sv",
+        "/rtl/encoder/multi_in_bundler_set.sv",
+        "/rtl/encoder/id_level_encoder.sv",
+    ]
+
+    toplevel = "id_level_encoder"
+    module = "test_id_level_encoder"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/test_id_level_encoder.py
+++ b/tests/test_id_level_encoder.py
@@ -55,7 +55,7 @@ level_set = vsax.hv_gen_orthogonal_im(
 
 def hv_to_int(hv: np.ndarray) -> int:
     """Convert a binary hypervector (1D numpy array of 0s/1s) to an integer."""
-    return int(np.packbits(hv, bitorder="little").tobytes().hex(), 16)
+    return int(np.packbits(hv, bitorder="big").tobytes().hex(), 16)
 
 
 # Load input HVs of num inputs size
@@ -119,7 +119,7 @@ async def id_level_encoder_dut(dut):
         expected_bundled_hv = vsax.hv_gen_empty(HV_DIMENSION)
         for _ in range(num_loads):
             expected_bundled_hv += await load_inputs(dut)
-
+        expected_bundled_hv = expected_bundled_hv[::-1]
         # Read actual bundled HV from DUT output
         actual_bundled_hv = np.array(
             [dut.hv_encoded_o[j].value.signed_integer for j in range(HV_DIMENSION)]

--- a/tests/test_id_level_encoder.py
+++ b/tests/test_id_level_encoder.py
@@ -26,7 +26,7 @@ sys.path.append(lib_path)
 import vsax  # noqa: E402
 
 # Global parameters
-HV_DIMENSION = 8
+HV_DIMENSION = 128
 COUNTER_WIDTH = 8
 NUM_INPUTS = 4
 HV_TYPE = "binary"


### PR DESCRIPTION
This PR adds the ID-level encoder module that is tuned for any ID-level encoding block.
It already utilizes the multi-bundler input as well so we can somehow estimate the run-time later for multiple encoding.

TODO:
- [x] Make RTL
- [x] Add ID-level encoder test
- [x] Add and update CI to include tests