### PR TITLE
Add SRAM memory module

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -106,6 +106,7 @@ rtl-im-check = """
 
 rtl-common-check = """
     pytest -n $(nproc) --dist=loadfile \
+    tests/test_sram_memory.py \
     tests/test_adder_tree.py \
     tests/test_fifo.py
     """

--- a/rtl/common/sram_memory.sv
+++ b/rtl/common/sram_memory.sv
@@ -1,0 +1,93 @@
+// ===============================================================================
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module:
+//    Generic memory unit with byte-enable and configurable Latency
+// Description:
+//    A simple memory module that can be used for various purposes.
+//   Supports byte-enable for writes and can be configured to have a read Latency.
+// Parameters:
+//    NumWords: number of words in the memory (default 256)
+//    DataWidth: width of each word in bits (default 32)
+//    ByteWidth: number of bytes in each word (default 4 for 32-bit words)
+//    Latency: number of cycles for read Latency (default 1)
+// IO ports:
+//    clk_i: clock input
+//    rst_ni: active-low reset input
+//    req_i: request signal to trigger read/write operations
+//    w_en_i: write enable signal (1 for write, 0 for read)
+//    addr_i: address input for read/write operations
+//    w_data_i: data input for write operations
+//    b_en_i: byte enable input for write operations (1 bit per byte)
+//    r_data_o: data output for read operations
+// ===============================================================================
+
+
+module sram_memory #(
+  parameter int unsigned NumWords       = 256,
+  parameter int unsigned DataWidth      = 32,
+  parameter int unsigned ByteWidth      = 8,
+  parameter int unsigned Latency        = 1,
+  // Don't touch parameters
+  parameter int unsigned AddrWidth      = $clog2(NumWords),
+  parameter int unsigned AddrByteWidth  = DataWidth / ByteWidth
+)(
+  // Clock and reset
+  input  logic                     clk_i,
+  input  logic                     rst_ni,
+  // Inputs
+  input  logic                     req_i,
+  input  logic                     w_en_i,
+  input  logic [    AddrWidth-1:0] addr_i,
+  input  logic [    DataWidth-1:0] w_data_i,
+  input  logic [AddrByteWidth-1:0] b_en_i,
+  // Outputs
+  output logic [    DataWidth-1:0] r_data_o
+);
+
+  //---------------------------
+  // Wires and regs
+  //---------------------------
+  logic [DataWidth-1:0] memory [NumWords];
+
+  //---------------------------
+  // Main memory logic
+  //---------------------------
+  // Writing to memory logic
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // Reset memory
+      for (int i = 0; i < NumWords; i++) begin
+        memory[i] <= {DataWidth{1'b0}};
+      end
+    end else if (req_i) begin
+      if (w_en_i) begin
+        // Write operation but with byte masking
+        for (int i = 0; i < ByteWidth; i++) begin
+          if (b_en_i[i]) begin
+            memory[addr_i][(i*8)+:8] <= w_data_i[(i*8)+:8];
+          end
+        end
+      end
+    end
+  end
+
+  // Reading from memory logic
+  if(Latency > 0) begin: gen_sram_memory_latency
+    // Latency logic
+    logic [DataWidth-1:0] r_data_reg;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        r_data_reg <= {DataWidth{1'b0}};
+      end else if (req_i) begin
+        r_data_reg <= memory[addr_i];
+      end
+    end
+    assign r_data_o = r_data_reg;
+  end else begin: gen_sram_memory_no_latency
+    // No Latency logic
+    assign r_data_o = memory[addr_i];
+  end
+
+endmodule

--- a/tests/test_sram_memory.py
+++ b/tests/test_sram_memory.py
@@ -1,0 +1,172 @@
+"""
+Copyright 2024 KU Leuven
+Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+Description:
+This tests the basic functionality of the
+generic SRAM memory module with byte-enable
+and configurable latency
+"""
+
+from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
+
+import cocotb
+from cocotb.clock import Clock
+import pytest
+
+# Some local parameters for testing
+DATA_WIDTH = 32
+NUM_WORDS = 256
+BYTE_WIDTH = 8
+LATENCY = 1
+
+# Derived
+NUM_BYTES = DATA_WIDTH // BYTE_WIDTH
+ALL_BYTES_EN = (1 << NUM_BYTES) - 1
+
+
+# Set inputs to 0
+def clear_inputs_no_clock(dut):
+    dut.req_i.value = 0
+    dut.w_en_i.value = 0
+    dut.addr_i.value = 0
+    dut.w_data_i.value = 0
+    dut.b_en_i.value = 0
+
+
+# Write a word to the SRAM (all bytes enabled)
+async def write_sram(dut, addr, data, b_en=ALL_BYTES_EN):
+    dut.req_i.value = 1
+    dut.w_en_i.value = 1
+    dut.addr_i.value = addr
+    dut.w_data_i.value = data
+    dut.b_en_i.value = b_en
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+
+
+# Read a word from the SRAM (with latency=1, data valid after the clock)
+async def read_sram(dut, addr):
+    dut.req_i.value = 1
+    dut.w_en_i.value = 0
+    dut.addr_i.value = addr
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    return dut.r_data_o.value.integer
+
+
+@cocotb.test()
+async def sram_memory_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Testing SRAM Memory Module        ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Initialize inputs
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    # Initialize clock
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Hold reset for one cycle
+    await clock_and_time(dut.clk_i)
+    dut.rst_ni.value = 1
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("        Write and read back all words       ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    rand_data_list = [gen_rand_bits(DATA_WIDTH) for _ in range(NUM_WORDS)]
+
+    for i in range(NUM_WORDS):
+        await write_sram(dut, i, rand_data_list[i])
+
+    for i in range(NUM_WORDS):
+        val = await read_sram(dut, i)
+        check_result(val, rand_data_list[i])
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("          Test byte-enable masking          ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Write a known full word first
+    await write_sram(dut, 0, 0xDEADBEEF)
+
+    # Overwrite only the lowest byte (b_en=0b0001) with 0xAB
+    new_byte = 0xAB
+    await write_sram(dut, 0, new_byte, b_en=0b0001)
+
+    val = await read_sram(dut, 0)
+    expected = (0xDEADBE00) | new_byte
+    check_result(val, expected)
+
+    # Overwrite only the highest byte (b_en=0b1000) with 0x12
+    new_byte_high = 0x12
+    await write_sram(dut, 0, new_byte_high << 24, b_en=0b1000)
+
+    val = await read_sram(dut, 0)
+    expected = (0x12ADBE00) | new_byte
+    check_result(val, expected)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         Test reset clears memory           ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Write something, then reset
+    await write_sram(dut, 5, 0xCAFEBABE)
+
+    dut.rst_ni.value = 0
+    await clock_and_time(dut.clk_i)
+    dut.rst_ni.value = 1
+
+    val = await read_sram(dut, 5)
+    check_result(val, 0)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("      No-req: output should not change      ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Write a known value
+    await write_sram(dut, 10, 0x12345678)
+    # Read it once to latch
+    val = await read_sram(dut, 10)
+    check_result(val, 0x12345678)
+
+    # Issue no request; r_data_o should hold last latched value
+    clear_inputs_no_clock(dut)
+    await clock_and_time(dut.clk_i)
+    check_result(dut.r_data_o.value.integer, 0x12345678)
+
+
+# Actual test run
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "NumWords": str(NUM_WORDS),
+            "DataWidth": str(DATA_WIDTH),
+            "ByteWidth": str(BYTE_WIDTH),
+            "Latency": str(LATENCY),
+        }
+    ],
+)
+def test_sram_memory(simulator, parameters, waves):
+    verilog_sources = ["/rtl/common/sram_memory.sv"]
+
+    toplevel = "sram_memory"
+
+    module = "test_sram_memory"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )


### PR DESCRIPTION
This PR simply adds a re-usable SRAM memory module. Although take note that it is not meant to be synthesizable, but rather it is meant to model an actual SRAM memory only. Make sure to replace it with the appropriate SRAM module generated by your own technology.

TODO:
- [x] Add SRAM rtl
- [x] Add test for SRAM memory
- [x] Add to pixi