### PR TITLE
Adding latch memory

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -107,6 +107,7 @@ rtl-im-check = """
 rtl-common-check = """
     pytest -n $(nproc) --dist=loadfile \
     tests/test_sram_memory.py \
+    tests/test_latch_memory.py \
     tests/test_adder_tree.py \
     tests/test_fifo.py
     """

--- a/rtl/common/latch_memory.sv
+++ b/rtl/common/latch_memory.sv
@@ -1,0 +1,179 @@
+// ===============================================================================
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module:
+//    Latch-based memory with synchronous write controller and valid-ready handshake
+// Description:
+//    A latch-based memory where the write path is guarded by a 3-cycle synchronous
+//    controller to ensure safe latch timing.
+//    Cycle 0 (IDLE)  : w_addr_i and w_data_i are captured into captured_addr and
+//                      captured_w_data on a valid_i transaction.
+//    Cycle 1 (WRITE) : reg_word_w_en is asserted from captured_addr, opening the
+//                      target latch. reg_word_w_en is a registered signal to prevent
+//                      any glitching from upstream combinational logic reaching the
+//                      latch enables.
+//    Cycle 2 (CLEAR) : reg_word_w_en is cleared (closing the latch), and
+//                      captured_addr and captured_w_data are also cleared before
+//                      the controller returns to IDLE.
+//    The read path is a direct combinational read from r_addr_i, fully independent
+//    of the write controller.
+// Parameters:
+//    NumWords  : number of words in the memory (default 256)
+//    DataWidth : width of each word in bits (default 32)
+// IO ports:
+//    clk_i     : clock input
+//    rst_ni    : active-low reset input
+//    valid_i   : upstream valid signal (initiates a write when high and ready)
+//    ready_o   : downstream ready signal (low during WRITE and CLEAR cycles)
+//    w_en_i    : write enable (1 for write, 0 for no-op, qualified by valid_i)
+//    w_addr_i  : write address input
+//    r_addr_i  : read address input (combinational, independent of write)
+//    w_data_i  : data input for write operations
+//    r_data_o  : data output for read operations (combinational)
+// ===============================================================================
+
+
+module latch_memory #(
+  parameter int unsigned NumWords  = 256,
+  parameter int unsigned DataWidth = 32,
+  // Don't touch parameters
+  parameter int unsigned AddrWidth = $clog2(NumWords)
+)(
+  // Clock and reset
+  input  logic                 clk_i,
+  input  logic                 rst_ni,
+  // Valid-ready handshake
+  input  logic                 valid_i,
+  output logic                 ready_o,
+  // Write inputs
+  input  logic                 w_en_i,
+  input  logic [AddrWidth-1:0] w_addr_i,
+  input  logic [DataWidth-1:0] w_data_i,
+  // Read inputs and outputs
+  input  logic [AddrWidth-1:0] r_addr_i,
+  output logic [DataWidth-1:0] r_data_o
+);
+
+  //---------------------------
+  // Wires and regs
+  //---------------------------
+  logic [DataWidth-1:0] memory [NumWords];
+
+  // Capture registers
+  // Cycle 0 (IDLE): inputs are captured here on a valid transaction
+  logic [AddrWidth-1:0] captured_addr;
+  logic [DataWidth-1:0] captured_w_data;
+  logic                 captured_w_en;
+
+  // Registered per-word write enables
+  // Asserted in WRITE, cleared in CLEAR — purely a register output,
+  // no combinational logic between this and the latch enables
+  logic [NumWords-1:0] reg_word_w_en;
+
+  // Controller state
+  typedef enum logic [1:0] {
+    IDLE  = 2'b00,
+    WRITE = 2'b01,
+    CLEAR_WEN = 2'b10,
+    CLEAR_CAPTURES = 2'b11
+  } fsm_state_t;
+
+  fsm_state_t ctrl_state;
+
+  //---------------------------
+  // Synchronous write controller
+  //---------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // Capture registers
+      captured_addr   <= '0;
+      captured_w_data <= '0;
+      captured_w_en   <= 1'b0;
+      // All reg-word enables
+      for (int i = 0; i < NumWords; i++) begin
+        reg_word_w_en[i] <= 1'b0;
+      end
+      // Handshake
+      ready_o         <= 1'b1;
+      // State
+      ctrl_state      <= IDLE;
+    end else begin
+      case (ctrl_state)
+
+        IDLE: begin
+          // Cycle 0: capture inputs on a valid transaction
+          if (valid_i) begin
+            captured_addr   <= w_addr_i;
+            captured_w_data <= w_data_i;
+            captured_w_en   <= w_en_i;
+            ready_o         <= 1'b0; // Not ready during WRITE and CLEAR cycles
+            ctrl_state      <= WRITE;
+          end
+        end
+
+        WRITE: begin
+          // Cycle 1: register the decoded word enable from captured_addr
+          // reg_word_w_en is a clean flip-flop output — no glitch path to latches
+          if (captured_w_en) begin
+            reg_word_w_en[captured_addr] <= 1'b1;
+          end
+          ctrl_state <= CLEAR_WEN;
+        end
+
+        CLEAR_WEN: begin
+          // Cycle 2: clear reg_word_w_en to close the latch
+          reg_word_w_en[captured_addr] <= 1'b0;
+          captured_w_en   <= 1'b0;
+          ctrl_state      <= CLEAR_CAPTURES;
+        end
+
+        CLEAR_CAPTURES: begin
+          // Cycle 3: clear captured address and data before returning to IDLE
+          captured_addr   <= '0;
+          captured_w_data <= '0;
+          ready_o         <= 1'b1;
+          ctrl_state      <= IDLE;
+        end
+
+        default: begin
+          // Capture registers
+          captured_addr   <= '0;
+          captured_w_data <= '0;
+          captured_w_en   <= 1'b0;
+          // All reg-word enables
+          for (int i = 0; i < NumWords; i++) begin
+            reg_word_w_en[i] <= 1'b0;
+          end
+          // Handshake
+          ready_o         <= 1'b1;
+          // State
+          ctrl_state      <= IDLE;
+        end
+
+      endcase
+    end
+  end
+
+  //---------------------------
+  // Latch array write logic
+  //---------------------------
+  // Each word has its own latch gated by reg_word_w_en[i].
+  // reg_word_w_en is asserted in WRITE (after capture) and cleared in CLEAR,
+  // giving a clean one-cycle window with no combinational glitch paths.
+  generate
+    for (genvar i = 0; i < NumWords; i++) begin : gen_latch_words
+      always_latch begin
+        if (reg_word_w_en[i]) begin
+          memory[i] = captured_w_data;
+        end
+      end
+    end
+  endgenerate
+
+  //---------------------------
+  // Combinational read logic
+  //---------------------------
+  assign r_data_o = memory[r_addr_i];
+
+endmodule

--- a/tests/test_latch_memory.py
+++ b/tests/test_latch_memory.py
@@ -1,0 +1,295 @@
+"""
+Copyright 2024 KU Leuven
+Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+
+Description:
+This tests the basic functionality of the latch-based memory
+module with a synchronous write controller and valid-ready
+handshake. The write path takes 4 cycles (IDLE -> WRITE ->
+CLEAR_WEN -> CLEAR_CAPTURES) and the read path is purely
+combinational.
+
+All addresses and data values are derived at runtime from
+NUM_WORDS and DATA_WIDTH so the test is valid for any
+parameterisation passed in via pytest.
+"""
+
+from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
+
+import random
+import cocotb
+from cocotb.clock import Clock
+import pytest
+
+# --------------------------------------------------
+# Top-level parameters — change here and everywhere
+# in the test adapts automatically
+# --------------------------------------------------
+DATA_WIDTH = 32
+NUM_WORDS = 32
+MAX_DATA = (1 << DATA_WIDTH) - 1
+
+
+# --------------------------------------------------
+# Helper: pick N unique random addresses within range
+# --------------------------------------------------
+def rand_addr(NUM_WORDS, count=1):
+    """Return `count` unique random addresses in [0, NUM_WORDS)."""
+    return random.sample(range(NUM_WORDS), count)
+
+
+# --------------------------------------------------
+# Helper: clear all inputs without clocking
+# --------------------------------------------------
+def clear_inputs_no_clock(dut):
+    dut.valid_i.value = 0
+    dut.w_en_i.value = 0
+    dut.w_addr_i.value = 0
+    dut.w_data_i.value = 0
+    dut.r_addr_i.value = 0
+
+
+# --------------------------------------------------
+# Helper: perform a single write transaction
+#
+# Timing (4 cycles total):
+#   Cycle 0 (IDLE)         : assert valid_i + write inputs, clock once
+#                            → FSM captures inputs, ready_o goes low
+#   Cycles 1-3 (WRITE /    : poll ready_o each cycle until it returns high
+#               CLEAR_WEN /  → FSM completes WRITE, CLEAR_WEN, CLEAR_CAPTURES
+#               CLEAR_CAPTURES)
+# --------------------------------------------------
+async def write_latch(dut, addr, data):
+    # Cycle 0: present transaction to the FSM
+    dut.valid_i.value = 1
+    dut.w_en_i.value = 1
+    dut.w_addr_i.value = addr
+    dut.w_data_i.value = data
+    await clock_and_time(dut.clk_i)
+
+    # De-assert immediately after capture — inputs no longer needed
+    clear_inputs_no_clock(dut)
+
+    # Wait for the FSM to finish WRITE -> CLEAR_WEN -> CLEAR_CAPTURES
+    # ready_o is registered, goes high at the end of CLEAR_CAPTURES
+    while not dut.ready_o.value:
+        await clock_and_time(dut.clk_i)
+
+
+# --------------------------------------------------
+# Helper: perform a no-op valid transaction (w_en_i=0)
+#
+# This exercises the path where valid_i fires but w_en_i is
+# deasserted, so captured_w_en=0 and reg_word_w_en is never set.
+# Memory content at the given address should remain unchanged.
+# --------------------------------------------------
+async def noop_latch(dut, addr, data):
+    dut.valid_i.value = 1
+    dut.w_en_i.value = 0  # no write
+    dut.w_addr_i.value = addr
+    dut.w_data_i.value = data
+    await clock_and_time(dut.clk_i)
+
+    clear_inputs_no_clock(dut)
+
+    while not dut.ready_o.value:
+        await clock_and_time(dut.clk_i)
+
+
+# --------------------------------------------------
+# Helper: combinational read — no clock required
+#
+# The read path is: r_data_o = memory[r_addr_i]
+# Simply drive r_addr_i and sample r_data_o immediately.
+# --------------------------------------------------
+async def read_latch(dut, addr):
+    dut.r_addr_i.value = addr
+    await clock_and_time(dut.clk_i)
+    return dut.r_data_o.value.integer
+
+
+# --------------------------------------------------
+# Main test
+# --------------------------------------------------
+@cocotb.test()
+async def latch_memory_dut(dut):
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("        Testing Latch Memory Module         ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    cocotb.log.info(f" NumWords={NUM_WORDS}, DataWidth={DATA_WIDTH}")
+
+    # Initialize inputs and hold reset
+    clear_inputs_no_clock(dut)
+    dut.rst_ni.value = 0
+
+    # Start clock (10 ns period)
+    clock = Clock(dut.clk_i, 10, units="ns")
+    cocotb.start_soon(clock.start(start_high=False))
+
+    # Hold reset for two cycles to ensure all flops settle
+    await clock_and_time(dut.clk_i)
+    await clock_and_time(dut.clk_i)
+    dut.rst_ni.value = 1
+
+    # Verify ready_o is asserted after reset before proceeding
+    await clock_and_time(dut.clk_i)
+    check_result(dut.ready_o.value.integer, 1)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("      Write and read back all words         ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # One random data value per word — adapts to any NUM_WORDS/DATA_WIDTH
+    rand_data_list = [gen_rand_bits(DATA_WIDTH) for _ in range(NUM_WORDS)]
+    print(rand_data_list)
+    for i in range(NUM_WORDS):
+        await write_latch(dut, i, rand_data_list[i])
+
+    # Verify all words — read is combinational so no clocking needed
+    for i in range(NUM_WORDS):
+        val = await read_latch(dut, i)
+        check_result(val, rand_data_list[i])
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("    Verify ready_o handshake timing         ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Use a random valid address and data for the timing probe
+    timing_addr = rand_addr(NUM_WORDS)[0]
+    timing_data = gen_rand_bits(DATA_WIDTH)
+
+    dut.valid_i.value = 1
+    dut.w_en_i.value = 1
+    dut.w_addr_i.value = timing_addr
+    dut.w_data_i.value = timing_data
+
+    # Cycle 0 → IDLE: clock the capture, ready_o should go low
+    await clock_and_time(dut.clk_i)
+    clear_inputs_no_clock(dut)
+    check_result(dut.ready_o.value.integer, 0)
+
+    # Cycle 1 → WRITE: still busy
+    await clock_and_time(dut.clk_i)
+    check_result(dut.ready_o.value.integer, 0)
+
+    # Cycle 2 → CLEAR_WEN: still busy
+    await clock_and_time(dut.clk_i)
+    check_result(dut.ready_o.value.integer, 0)
+
+    # Cycle 3 → CLEAR_CAPTURES: ready_o goes high at end of this cycle
+    await clock_and_time(dut.clk_i)
+    check_result(dut.ready_o.value.integer, 1)
+
+    # Confirm the data was actually committed at the random address
+    val = await read_latch(dut, timing_addr)
+    check_result(val, timing_data)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("    Read is combinational (no clock)        ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Pick two distinct random addresses — guaranteed valid for any NUM_WORDS
+    addr_a, addr_b = rand_addr(NUM_WORDS, count=2)
+    data_a = gen_rand_bits(DATA_WIDTH)
+
+    # Write to addr_a then read back immediately without a clock edge
+    await write_latch(dut, addr_a, data_a)
+    val = await read_latch(dut, addr_a)
+    check_result(val, data_a)
+
+    # Switching r_addr_i to addr_b instantly reflects that word —
+    # addr_b was written during the "write and read back all words" test
+    val = await read_latch(dut, addr_b)
+    check_result(val, rand_data_list[addr_b])
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("  No-op transaction does not modify memory  ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Pick a random address, write a known value, then issue a no-op
+    # with different data and confirm the word is unchanged
+    noop_addr = rand_addr(NUM_WORDS)[0]
+    noop_data_original = gen_rand_bits(DATA_WIDTH)
+    noop_data_intruder = gen_rand_bits(DATA_WIDTH)
+
+    # Ensure the intruder value is actually different
+    while noop_data_intruder == noop_data_original:
+        noop_data_intruder = gen_rand_bits(DATA_WIDTH)
+
+    await write_latch(dut, noop_addr, noop_data_original)
+    check_result(await read_latch(dut, noop_addr), noop_data_original)
+
+    await noop_latch(dut, noop_addr, noop_data_intruder)
+    check_result(await read_latch(dut, noop_addr), noop_data_original)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("  Overwrite: second write replaces first    ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    overwrite_addr = rand_addr(NUM_WORDS)[0]
+    overwrite_first = gen_rand_bits(DATA_WIDTH)
+    overwrite_second = gen_rand_bits(DATA_WIDTH)
+
+    # Ensure both values differ so the overwrite is detectable
+    while overwrite_second == overwrite_first:
+        overwrite_second = gen_rand_bits(DATA_WIDTH)
+
+    await write_latch(dut, overwrite_addr, overwrite_first)
+    check_result(await read_latch(dut, overwrite_addr), overwrite_first)
+
+    await write_latch(dut, overwrite_addr, overwrite_second)
+    check_result(await read_latch(dut, overwrite_addr), overwrite_second)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("  Consecutive writes to different addresses ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Pick 3 unique random addresses and pair each with random data
+    consec_addrs = rand_addr(NUM_WORDS, count=3)
+    consec_pairs = [(a, gen_rand_bits(DATA_WIDTH)) for a in consec_addrs]
+
+    for addr, data in consec_pairs:
+        await write_latch(dut, addr, data)
+
+    for addr, data in consec_pairs:
+        check_result(await read_latch(dut, addr), data)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         All tests passed!                  ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+
+# --------------------------------------------------
+# Pytest entry point
+# --------------------------------------------------
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {
+            "NumWords": str(NUM_WORDS),
+            "DataWidth": str(DATA_WIDTH),
+        }
+    ],
+)
+def test_latch_memory(simulator, parameters, waves):
+    verilog_sources = ["/rtl/common/latch_memory.sv"]
+
+    toplevel = "latch_memory"
+
+    module = "test_latch_memory"
+
+    setup_and_run(
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        simulator=simulator,
+        parameters=parameters,
+        waves=waves,
+    )

--- a/tests/test_sram_memory.py
+++ b/tests/test_sram_memory.py
@@ -3,18 +3,25 @@ Copyright 2024 KU Leuven
 Ryan Antonio <ryan.antonio@esat.kuleuven.be>
 
 Description:
-This tests the basic functionality of the
-generic SRAM memory module with byte-enable
-and configurable latency
+This tests the basic functionality of the generic SRAM memory
+module with byte-enable and configurable latency.
+
+All addresses and data values are derived at runtime from
+NUM_WORDS, DATA_WIDTH, and BYTE_WIDTH so the test is valid
+for any parameterisation passed in via pytest.
 """
 
 from util import setup_and_run, gen_rand_bits, clock_and_time, check_result
 
+import random
 import cocotb
 from cocotb.clock import Clock
 import pytest
 
-# Some local parameters for testing
+# --------------------------------------------------
+# Top-level parameters — change here and everywhere
+# in the test adapts automatically
+# --------------------------------------------------
 DATA_WIDTH = 32
 NUM_WORDS = 256
 BYTE_WIDTH = 8
@@ -25,7 +32,24 @@ NUM_BYTES = DATA_WIDTH // BYTE_WIDTH
 ALL_BYTES_EN = (1 << NUM_BYTES) - 1
 
 
-# Set inputs to 0
+# --------------------------------------------------
+# Helper: pick N unique random addresses within range
+# --------------------------------------------------
+def rand_addr(num_words, count=1):
+    """Return `count` unique random addresses in [0, num_words)."""
+    return random.sample(range(num_words), count)
+
+
+# --------------------------------------------------
+# Helper: generate a random value fitting in one byte
+# --------------------------------------------------
+def rand_byte():
+    return random.randint(0x01, 0xFF)  # avoid 0 so changes are detectable
+
+
+# --------------------------------------------------
+# Helper: clear all inputs without clocking
+# --------------------------------------------------
 def clear_inputs_no_clock(dut):
     dut.req_i.value = 0
     dut.w_en_i.value = 0
@@ -34,7 +58,10 @@ def clear_inputs_no_clock(dut):
     dut.b_en_i.value = 0
 
 
-# Write a word to the SRAM (all bytes enabled)
+# --------------------------------------------------
+# Helper: write a word to the SRAM
+# b_en defaults to all bytes enabled
+# --------------------------------------------------
 async def write_sram(dut, addr, data, b_en=ALL_BYTES_EN):
     dut.req_i.value = 1
     dut.w_en_i.value = 1
@@ -45,7 +72,10 @@ async def write_sram(dut, addr, data, b_en=ALL_BYTES_EN):
     clear_inputs_no_clock(dut)
 
 
-# Read a word from the SRAM (with latency=1, data valid after the clock)
+# --------------------------------------------------
+# Helper: read a word from the SRAM
+# With Latency=1 the registered output is valid after the clock edge.
+# --------------------------------------------------
 async def read_sram(dut, addr):
     dut.req_i.value = 1
     dut.w_en_i.value = 0
@@ -55,21 +85,30 @@ async def read_sram(dut, addr):
     return dut.r_data_o.value.integer
 
 
+# --------------------------------------------------
+# Main test
+# --------------------------------------------------
 @cocotb.test()
 async def sram_memory_dut(dut):
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("          Testing SRAM Memory Module        ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Initialize inputs
+    cocotb.log.info(
+        f" NumWords={NUM_WORDS}, DataWidth={DATA_WIDTH}, "
+        f"ByteWidth={BYTE_WIDTH}, Latency={LATENCY}"
+    )
+
+    # Initialize inputs and hold reset
     clear_inputs_no_clock(dut)
     dut.rst_ni.value = 0
 
-    # Initialize clock
+    # Start clock (10 ns period)
     clock = Clock(dut.clk_i, 10, units="ns")
     cocotb.start_soon(clock.start(start_high=False))
 
-    # Hold reset for one cycle
+    # Hold reset for two cycles to ensure all flops settle
+    await clock_and_time(dut.clk_i)
     await clock_and_time(dut.clk_i)
     dut.rst_ni.value = 1
 
@@ -78,6 +117,7 @@ async def sram_memory_dut(dut):
     cocotb.log.info("        Write and read back all words       ")
     cocotb.log.info(" ------------------------------------------ ")
 
+    # One random data value per word — adapts to any NUM_WORDS/DATA_WIDTH
     rand_data_list = [gen_rand_bits(DATA_WIDTH) for _ in range(NUM_WORDS)]
 
     for i in range(NUM_WORDS):
@@ -92,58 +132,110 @@ async def sram_memory_dut(dut):
     cocotb.log.info("          Test byte-enable masking          ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Write a known full word first
-    await write_sram(dut, 0, 0xDEADBEEF)
+    # Pick a random address and write a random full word as the baseline
+    be_addr = rand_addr(NUM_WORDS)[0]
+    base_word = gen_rand_bits(DATA_WIDTH)
+    await write_sram(dut, be_addr, base_word)
 
-    # Overwrite only the lowest byte (b_en=0b0001) with 0xAB
-    new_byte = 0xAB
-    await write_sram(dut, 0, new_byte, b_en=0b0001)
+    current_word = base_word
 
-    val = await read_sram(dut, 0)
-    expected = (0xDEADBE00) | new_byte
-    check_result(val, expected)
+    # Walk through each byte lane: overwrite one byte at a time with a
+    # random value and verify that only the targeted byte changes
+    for byte_idx in range(NUM_BYTES):
+        new_byte = rand_byte()
+        byte_mask = 1 << byte_idx
+        byte_shift = byte_idx * BYTE_WIDTH
 
-    # Overwrite only the highest byte (b_en=0b1000) with 0x12
-    new_byte_high = 0x12
-    await write_sram(dut, 0, new_byte_high << 24, b_en=0b1000)
+        # Build expected: replace only the targeted byte in current_word
+        byte_clear = ~(0xFF << byte_shift) & ((1 << DATA_WIDTH) - 1)
+        expected = (current_word & byte_clear) | (new_byte << byte_shift)
 
-    val = await read_sram(dut, 0)
-    expected = (0x12ADBE00) | new_byte
-    check_result(val, expected)
+        # Write only the new byte value aligned to its position
+        await write_sram(dut, be_addr, new_byte << byte_shift, b_en=byte_mask)
+
+        val = await read_sram(dut, be_addr)
+        check_result(val, expected)
+
+        # Track the accumulating state for the next iteration
+        current_word = expected
 
     # --------------------------------------------------
     cocotb.log.info(" ------------------------------------------ ")
     cocotb.log.info("         Test reset clears memory           ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Write something, then reset
-    await write_sram(dut, 5, 0xCAFEBABE)
+    # Write random data to a random address, then reset
+    reset_addr = rand_addr(NUM_WORDS)[0]
+    reset_data = gen_rand_bits(DATA_WIDTH)
+    await write_sram(dut, reset_addr, reset_data)
 
     dut.rst_ni.value = 0
     await clock_and_time(dut.clk_i)
     dut.rst_ni.value = 1
 
-    val = await read_sram(dut, 5)
+    val = await read_sram(dut, reset_addr)
     check_result(val, 0)
 
     # --------------------------------------------------
     cocotb.log.info(" ------------------------------------------ ")
-    cocotb.log.info("      No-req: output should not change      ")
+    cocotb.log.info("  Overwrite: second write replaces first    ")
     cocotb.log.info(" ------------------------------------------ ")
 
-    # Write a known value
-    await write_sram(dut, 10, 0x12345678)
-    # Read it once to latch
-    val = await read_sram(dut, 10)
-    check_result(val, 0x12345678)
+    overwrite_addr = rand_addr(NUM_WORDS)[0]
+    overwrite_first = gen_rand_bits(DATA_WIDTH)
+    overwrite_second = gen_rand_bits(DATA_WIDTH)
 
-    # Issue no request; r_data_o should hold last latched value
+    # Ensure both values differ so the overwrite is detectable
+    while overwrite_second == overwrite_first:
+        overwrite_second = gen_rand_bits(DATA_WIDTH)
+
+    await write_sram(dut, overwrite_addr, overwrite_first)
+    check_result(await read_sram(dut, overwrite_addr), overwrite_first)
+
+    await write_sram(dut, overwrite_addr, overwrite_second)
+    check_result(await read_sram(dut, overwrite_addr), overwrite_second)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("  Consecutive writes to different addresses ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Pick 3 unique random addresses and pair each with random data
+    consec_addrs = rand_addr(NUM_WORDS, count=3)
+    consec_pairs = [(a, gen_rand_bits(DATA_WIDTH)) for a in consec_addrs]
+
+    for addr, data in consec_pairs:
+        await write_sram(dut, addr, data)
+
+    for addr, data in consec_pairs:
+        check_result(await read_sram(dut, addr), data)
+
+    # --------------------------------------------------
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("      No-req: output should hold last value ")
+    cocotb.log.info(" ------------------------------------------ ")
+
+    # Write and read a random word to prime the output register
+    noreq_addr = rand_addr(NUM_WORDS)[0]
+    noreq_data = gen_rand_bits(DATA_WIDTH)
+    await write_sram(dut, noreq_addr, noreq_data)
+
+    val = await read_sram(dut, noreq_addr)
+    check_result(val, noreq_data)
+
+    # Issue no request — r_data_o must hold the last registered value
     clear_inputs_no_clock(dut)
     await clock_and_time(dut.clk_i)
-    check_result(dut.r_data_o.value.integer, 0x12345678)
+    check_result(dut.r_data_o.value.integer, noreq_data)
+
+    cocotb.log.info(" ------------------------------------------ ")
+    cocotb.log.info("         All tests passed!                  ")
+    cocotb.log.info(" ------------------------------------------ ")
 
 
-# Actual test run
+# --------------------------------------------------
+# Pytest entry point
+# --------------------------------------------------
 @pytest.mark.parametrize(
     "parameters",
     [


### PR DESCRIPTION
In this PR we add the latch memory. What's unique to the latch is that it has a registered control such that when it gets to the latches it will turn out glitchless.  Since latches are sensitive to when the access it transparent (i.e. `wen=1`).

TODO:
- [x] Add latch RTL
- [x] Add test for latch
- [x] Add to pixi
- [x] Upgrade SRAM test to parallel that of the latch