### PR TITLE
Add ID-level version for the binary MNIST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,30 +144,6 @@ jobs:
       - name: Run tests in parallel
         if: needs.changes.outputs.app == 'true'
         run: |
-          TASKS=(
-            app-test-vsax-digit-recog
-            app-test-vsax-bin-digit-recog
-            app-test-vsax-bin-idlvl-digit-recog
-          )
-          PIDS=()
-          mkdir -p logs
-
-          for TASK in "${TASKS[@]}"; do
-            pixi run $TASK > logs/$TASK.log 2>&1 &
-            PIDS+=($!)
-          done
-
-          FAILED=0
-          for PID in "${PIDS[@]}"; do
-            wait $PID || FAILED=1
-          done
-
-          if [ "$FAILED" = "1" ]; then exit 1; fi
-
-      - name: Print logs
-        if: always() && needs.changes.outputs.app == 'true'
-        run: |
-          for LOG in logs/*.log; do
-            echo "=== $LOG ==="
-            cat "$LOG"
-          done
+          pixi run app-test-vsax-digit-recog &&
+          pixi run app-test-vsax-bin-digit-recog &&
+          pixi run app-test-vsax-bin-idlvl-digit-recog &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,6 @@ jobs:
       - name: Run tests in parallel
         if: needs.changes.outputs.app == 'true'
         run: |
-          pixi run app-test-vsax-digit-recog &&
-          pixi run app-test-vsax-bin-digit-recog &&
-          pixi run app-test-vsax-bin-idlvl-digit-recog &&
+          pixi run app-test-vsax-digit-recog
+          pixi run app-test-vsax-bin-digit-recog
+          pixi run app-test-vsax-bin-idlvl-digit-recog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           TASKS=(
             app-test-vsax-digit-recog
             app-test-vsax-bin-digit-recog
+            app-test-vsax-bin-idlvl-digit-recog
           )
           PIDS=()
           mkdir -p logs

--- a/app/vsax_bin_digit_recog.py
+++ b/app/vsax_bin_digit_recog.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 # Global parameters
-HV_SIZE = 1024
+HV_SIZE = 512
 CLASS_LIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 GEN_TYPE = "lfsr"
 

--- a/app/vsax_bin_idlvl_digit_recog.py
+++ b/app/vsax_bin_idlvl_digit_recog.py
@@ -1,0 +1,133 @@
+"""
+VSAX Binary Digit Recognition Application
+
+This application demonstrates the use of VSAX
+for digit recognition using the MNIST dataset.
+This version does the binary ID-level encoding.
+Where we use binary MNIST images.
+"""
+
+# Parameters
+import os
+import sys
+from pathlib import Path
+
+# Global parameters
+HV_SIZE = 512
+CLASS_LIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+GEN_TYPE = "lfsr"
+
+# Path directories
+curr_dir = os.path.dirname(os.path.abspath(__file__))
+model_name = Path(__file__).stem
+lib_path = curr_dir + "/../lib"
+data_path = curr_dir + "/../data"
+dataset_path = data_path + "/mnist_bin"
+model_path = curr_dir + "/../models"
+
+# Appending other paths for libraries
+sys.path.append(lib_path)
+
+# Importing VSAX libraries
+import vsax  # noqa: E402
+import vsax_models  # noqa: E402
+import vsax_util  # noqa: E402
+
+(
+    save_mode,
+    load_mode,
+    disable_tqdm,
+) = vsax_models.vsax_general_parser()
+model_file = model_name + f"_d{HV_SIZE}.npz"
+model_dir = model_path + f"/{model_file}"
+
+
+# Download pre-trained model
+if load_mode:
+    vsax_util.download_file(
+        url=f"{vsax_util.git_trained_models_url}/{model_file}",
+        out_dir=model_path,
+        filename=model_file,
+    )
+
+# Downloading and extracting the MNIST dataset
+vsax_util.download_and_extract(
+    url=vsax_util.vsax_data_url_bin_mnist,
+    out_dir=data_path,
+    delete_archive=True,
+)
+
+# Read data
+X_data = vsax_util.read_data(CLASS_LIST, dataset_path, disable_tqdm=disable_tqdm)
+
+# Train and test split
+train_test_split = 0.6
+train_valid_split = 0.75
+
+X_train_set, X_valid_set, X_test_set = vsax_util.split_train_valid_test_set(
+    X_data=X_data,
+    class_list=CLASS_LIST,
+    train_test_split=train_test_split,
+    train_valid_split=train_valid_split,
+    disable_tqdm=disable_tqdm,
+)
+
+
+# Make class for digit model
+class digitVSA(vsax_models.vsaModel):
+    def encode(self, item_data):
+        # Feature length
+        item_len = len(item_data)
+        # Threshold for binarization
+        threshold = item_len // 2
+        # Encode hypervector
+        encoded_vec = vsax.hv_gen_empty(self.hv_size)
+        for i in range(item_len):
+            bind_id_level = vsax.hv_bind(
+                self.ortho_im[i + 2],  # level offset by 2
+                self.ortho_im[item_data[i]],  # 1st 2 are reserved for level encoding
+                self.hv_type,
+            )
+            encoded_vec += bind_id_level
+        # Binarization
+        if self.binarize_encode:
+            encoded_vec = vsax.hv_binarize(encoded_vec, threshold, self.hv_type)
+        return encoded_vec
+
+
+# Make digit class
+digit_model = digitVSA(
+    model_name=model_name,
+    hv_size=HV_SIZE,
+    class_list=CLASS_LIST,
+    gen_type=GEN_TYPE,
+)
+
+# Disabling TQDM debug progress bars
+digit_model.tqdm_train_disable = disable_tqdm
+digit_model.tqdm_retrain_disable = disable_tqdm
+digit_model.tqdm_test_disable = disable_tqdm
+
+if load_mode:
+    # Load an existing trained model
+    digit_model.load_model(model_dir)
+else:
+    # Train the model
+    digit_model.train_model(X_train_set)
+
+    # Retrain the model
+    digit_model.retrain_model(X_valid_set)
+
+# Test the model
+digit_model.test_model(X_test_set)
+
+# Print some statistics
+digit_model.print_model_stats()
+
+# Checker if accuracy is expected
+assert digit_model.model_accuracy > 0.8, "Test accuracy is lower than expected."
+print("✓ Test accuracy passed.")
+
+# Save model
+if save_mode:
+    digit_model.save_model(model_dir)

--- a/app/vsax_digit_recog.py
+++ b/app/vsax_digit_recog.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 # Global parameters
-HV_SIZE = 1024
+HV_SIZE = 512
 CLASS_LIST = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 # Path directories

--- a/lib/vsax_util.py
+++ b/lib/vsax_util.py
@@ -25,7 +25,7 @@ vsax_data_url_bin_mnist = "https://github.com/rgantonio/chronomatica/releases/do
 # ---------------------------------------------------------------------------
 # Main pre-trained model url
 # ---------------------------------------------------------------------------
-ver_trained_models = "v0.1.0"
+ver_trained_models = "v0.1.1"
 git_trained_models_url = f"https://github.com/KULeuven-MICAS/hypercorex/releases/download/vsax_trained_models_{ver_trained_models}"
 
 # ---------------------------------------------------------------------------

--- a/pixi.toml
+++ b/pixi.toml
@@ -127,6 +127,7 @@ rtl-assocmem-check = """
 # ── App Test Tasks─────────────────────────────────────────────────────────────
 app-test-vsax-digit-recog = "python app/vsax_digit_recog.py --load --dtqdm"
 app-test-vsax-bin-digit-recog = "python app/vsax_bin_digit_recog.py --load --dtqdm"
+app-test-vsax-bin-idlvl-digit-recog = "python app/vsax_bin_idlvl_digit_recog.py --load --dtqdm"
 
 # ── Docs Tasks ────────────────────────────────────────────────────────────────
 [feature.docs.tasks]


### PR DESCRIPTION
This PR adds the ID-level version of binary MNIST. The only difference is that the binary pixels are represented with hypervectors rather than circular permutations.

TODO:
- [x] Add test for ID-level

Modifications:
- [x] Convert other apps to use 512 for faster simulation
- [x] Add a release for the the pre-trained models