### PR TITLE
Initial Questasim simulation and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,74 @@
 # ==============================================================================
+# Directories
+# ==============================================================================
+# General
+ROOT_DIR  := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+LOGS_DIR := $(ROOT_DIR)logs
+
+# Questasim
+VSIM_BUILD_DIR:= $(ROOT_DIR)questa/work_vsim
+VSIM_TCL_DIR := $(ROOT_DIR)questa/vsim_tcl
+VSIM_FILELIST_DIR := $(ROOT_DIR)questa/vsim_flist
+
+# ==============================================================================
+# Questasim build and simulation
+# ==============================================================================
+VSIM_MODULE :=
+VSIM_MODULE_FILELIST := $(VSIM_FILELIST_DIR)/$(VSIM_MODULE)_flist.tcl
+
+VSIM_FLAGS = -t 1ps
+VSIM_FLAGS += -voptargs=+acc
+VSIM_FLAGS += -do "log -r /*; run -a"
+
+VOPT_FLAGS = +acc
+
+$(VSIM_BUILD_DIR):
+	mkdir -p $@
+$(VSIM_TCL_DIR):
+	mkdir -p $@
+$(LOGS_DIR):
+	mkdir -p $@
+
+$(VSIM_TCL_DIR)/$(VSIM_MODULE).vsim: $(VSIM_MODULE_FILELIST) | $(VSIM_TCL_DIR) $(VSIM_BUILD_DIR) $(LOGS_DIR)
+	touch $@
+	vsim -c -do "source $<; quit" | tee $(VSIM_BUILD_DIR)/vlog.log
+	@! grep -P "Errors: [1-9]*," $(VSIM_BUILD_DIR)/vlog.log
+	vopt $(VOPT_FLAGS) -work $(VSIM_BUILD_DIR) tb_$(VSIM_MODULE) -o $(VSIM_MODULE)_opt | tee $(VSIM_BUILD_DIR)/vopt.log
+	@! grep -P "Errors: [1-9]*," $(VSIM_BUILD_DIR)/vopt.log
+	@echo "#!/bin/bash" > $@
+	@echo 'vsim +permissive $(VSIM_FLAGS) -work $(VSIM_BUILD_DIR) -c \
+				$(VSIM_MODULE)_opt +permissive-off' >> $@
+	@chmod +x $@
+	@echo "#!/bin/bash" > $@.gui
+	@echo 'vsim +permissive $(VSIM_FLAGS) -work $(VSIM_BUILD_DIR) \
+				$(VSIM_MODULE)_opt +permissive-off' >> $@.gui
+	@chmod +x $@.gui
+
+build-vsim: $(VSIM_TCL_DIR)/$(VSIM_MODULE).vsim
+
+# ==============================================================================
 # Cleanup
 # ==============================================================================
 
 .PHONY: clean
 
+clean-all: clean clean-vsim
+
 clean:
 	@echo "Cleaning build artifacts..."
 	rm -rf __pycache__ tests/__pycache__ tests/sim_build
 	@echo "Done."
+
+clean-vsim:
+	@echo "Cleaning QuestaSim build artifacts..."
+	rm -rf $(VSIM_BUILD_DIR) $(VSIM_TCL_DIR) $(LOGS_DIR)
+	@echo "Done."
+
+# ==============================================================================
+# Debug
+# ==============================================================================
+show-dir:
+	@echo "ROOT_DIR: $(ROOT_DIR)"
+	@echo "VSIM_BUILD_DIR: $(VSIM_BUILD_DIR)"
+	@echo "VSIM_TCL_DIR: $(VSIM_TCL_DIR)"
+	@echo "LOGS_DIR: $(LOGS_DIR)"

--- a/rtl/tb/tb_vsax_id_level_top.sv
+++ b/rtl/tb/tb_vsax_id_level_top.sv
@@ -1,0 +1,139 @@
+//---------------------------
+// Copyright 2024 KU Leuven
+// Ryan Antonio <ryan.antonio@esat.kuleuven.be>
+//
+// Module: tb_vsax_id_level_top
+// Description:
+// Testbench for the vsax_id_level_top module. This testbench is designed to
+// verify the functionality of the vsax_id_level_top module by applying a series
+// of test vectors and checking the outputs against expected results.
+//---------------------------
+
+`define TCLK 1
+
+module tb_vsax_id_level_top #(
+  // General parameters
+  parameter int unsigned HVDimension        = 512,
+  parameter int unsigned CsrRegWidth        = 8,
+  // Item memory specific
+  parameter int unsigned SeedIm             = 32'hDEAD_BEEF,
+  parameter int unsigned ParallelInputsIm   = 2,
+  parameter int unsigned NumTotIm           = 1024,
+  // Encoder specific
+  parameter int unsigned ParallelInputsEnc  = ParallelInputsIm/2,
+  parameter int unsigned CounterWidthEnc    = 8,
+  // Assoc memory specific
+  parameter int unsigned NumClassAm         = 32,
+  // Don't touch!
+  parameter int unsigned ImSelWidth         = $clog2(NumTotIm),
+  parameter int unsigned AddrWidthAm        = $clog2(NumClassAm)
+);
+
+  // Clocks and reset
+  logic                          clk_i;
+  logic                          rst_ni;
+  // Item-memory iports
+  logic [       ImSelWidth-1:0]  im_rd_i [ParallelInputsIm];
+  // Encoding ports
+  logic [ParallelInputsEnc-1:0]  enc_valid_i;
+  logic                          enc_clr_i;
+  // Query hypervector register ports
+  logic                          qhv_wen_i;
+  logic                          qhv_clr_i;
+  logic                          qhv_am_load_i;
+  // Associative memory ports
+  // Write side (latch_memory)
+  logic                          w_valid_i;
+  logic                          w_ready_o;
+  logic                          w_en_i;
+  logic [       AddrWidthAm-1:0] w_addr_i;
+  logic [       HVDimension-1:0] w_data_i;
+  // External read port
+  logic                          external_read_sel_i;
+  logic                          ext_r_req_valid_i;
+  logic                          ext_r_req_ready_o;
+  logic [       AddrWidthAm-1:0] ext_r_addr_i;
+  logic                          ext_r_resp_valid_o;
+  logic                          ext_r_resp_ready_i;
+  logic [       HVDimension-1:0] ext_r_resp_data_o;
+  // Search control
+  logic                          am_start_i;
+  logic [       CsrRegWidth-1:0] am_num_class_i;
+  logic [       CsrRegWidth-1:0] predict_o;
+  logic                          predict_valid_o;
+  logic                          predict_ready_i;
+
+  // Instantiate the DUT
+  vsax_id_level_top #(
+    .HVDimension          ( HVDimension         ),
+    .CsrRegWidth          ( CsrRegWidth         ),
+    .SeedIm               ( SeedIm              ),
+    .ParallelInputsIm     ( ParallelInputsIm    ),
+    .NumTotIm             ( NumTotIm            ),
+    .ParallelInputsEnc    ( ParallelInputsEnc   ),
+    .CounterWidthEnc      ( CounterWidthEnc     ),
+    .NumClassAm           ( NumClassAm          )
+  ) i_vsax_id_level_top (
+    .clk_i                ( clk_i               ),
+    .rst_ni               ( rst_ni              ),
+    .im_rd_i              ( im_rd_i             ),
+    .enc_valid_i          ( enc_valid_i         ),
+    .enc_clr_i            ( enc_clr_i           ),
+    .qhv_wen_i            ( qhv_wen_i           ),
+    .qhv_clr_i            ( qhv_clr_i           ),
+    .qhv_am_load_i        ( qhv_am_load_i       ),
+    .w_valid_i            ( w_valid_i           ),
+    .w_ready_o            ( w_ready_o           ),
+    .w_en_i               ( w_en_i              ),
+    .w_addr_i             ( w_addr_i            ),
+    .w_data_i             ( w_data_i            ),
+    .external_read_sel_i  ( external_read_sel_i ),
+    .ext_r_req_valid_i    ( ext_r_req_valid_i   ),
+    .ext_r_req_ready_o    ( ext_r_req_ready_o   ),
+    .ext_r_addr_i         ( ext_r_addr_i        ),
+    .ext_r_resp_valid_o   ( ext_r_resp_valid_o  ),
+    .ext_r_resp_ready_i   ( ext_r_resp_ready_i  ),
+    .ext_r_resp_data_o    ( ext_r_resp_data_o   ),
+    .am_start_i           ( am_start_i          ),
+    .am_num_class_i       ( am_num_class_i      ),
+    .predict_o            ( predict_o           ),
+    .predict_valid_o      ( predict_valid_o     ),
+    .predict_ready_i      ( predict_ready_i     )
+  );
+
+  // Forever clock
+  initial begin
+    clk_i = 0;
+    forever #`TCLK clk_i = ~clk_i;
+  end
+
+  initial begin
+    // Initialize inputs
+    rst_ni              = '0;
+    for (int i = 0; i < ParallelInputsIm; i++)
+      im_rd_i[i]        = '0;
+    enc_valid_i         = '0;
+    enc_clr_i           = '0;
+    qhv_wen_i           = '0;
+    qhv_clr_i           = '0;
+    qhv_am_load_i       = '0;
+    w_valid_i           = '0;
+    w_en_i              = '0;
+    w_addr_i            = '0;
+    w_data_i            = '0;
+    external_read_sel_i = '0;
+    ext_r_req_valid_i   = '0;
+    ext_r_addr_i        = '0;
+    ext_r_resp_ready_i  = '0;
+    am_start_i          = '0;
+    am_num_class_i      = '0;
+    predict_ready_i     = '0;
+    @(posedge clk_i);
+    rst_ni = '1;
+    @(posedge clk_i);
+
+    // Trailing clock cycles
+    for(int i=0; i<10; i++) @(posedge clk_i);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This PR is meant to setup properly the questasim simulation and testing to automate it as much as possible.

Reasons:
- The caveat to using purely cocotb is that sometimes it is difficult to port to private servers that have NDA issues. This happens particularly on synthesized or PnR'd work where we have to do gate-level simulations. Ideally, we would just like to do a simple switch of RTL netlists but that's not the case in certain work environments...
- The other problem is to have manual trigger of simulation dumping switching activity factors. That is a bit more manual down into the system verilog level. So we introduce the use of Questasim in here.


Some problems we see:
- Verilator cannot compile large designs. Even with other switches the compile time becomes unbearable (hours) so we need to find other alternatives.
- Iverilog or icarus is one but the problem is that it has more limitations to what features of system verilog it can do.


TODO:
- [x] Add vanilla testbench for the vsax_id_level_top
- [x] Add questasim setup and simulation for it.